### PR TITLE
release 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "hl"
-version = "0.11.2"
+version = "0.12.0-alpha.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "hl"
-version = "0.12.0-alpha.0"
+version = "0.12.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.11.2"
+version = "0.12.0-alpha.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.12.0-alpha.0"
+version = "0.12.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Log viewer which translates JSON logs into pretty human-readable representation.
 - Command
 
     ```
-    $ hl example.log --show provider
+    $ hl example.log --hide '*' --hide '!provider'
     ```
     Hides all fields except `provider`.
 
@@ -186,7 +186,7 @@ Log viewer which translates JSON logs into pretty human-readable representation.
 - Command
 
     ```
-    $ hl example.log -h headers -h body -H headers.content-type
+    $ hl example.log -h headers -h body -h '!headers.content-type'
     ```
     Hides fields `headers` and `body` but shows a single sub-field `content-type` inside field `headers`.
 
@@ -297,7 +297,7 @@ Log viewer which translates JSON logs into pretty human-readable representation.
 ### Complete set of options and flags
 
 ```
-hl 0.11.0
+hl 0.12.0
 JSON log converter to human readable representation
 
 USAGE:
@@ -314,8 +314,7 @@ OPTIONS:
     -e, --hide-empty-fields                                  Hide empty fields, applies for null, string, object and array fields only [env: HL_HIDE_EMPTY_FIELDS=]
     -E, --show-empty-fields                                  Show empty fields, overrides --hide-empty-fields option [env: HL_SHOW_EMPTY_FIELDS=]
     -f, --filter <FILTER>                                    Filtering by field values in one of forms [<key>=<value>, <key>~=<value>, <key>~~=<value>, <key>!=<value>, <key>!~=<value>, <key>!~~=<value>] where ~ denotes substring match and ~~ denotes regular expression match
-    -h, --hide <HIDE>                                        Hide fields with the specified keys
-    -H, --show <SHOW>                                        Hide all fields except fields with the specified keys
+    -h, --hide <HIDE>                                        Hide or unhide fields with the specified keys, prefix with ! to unhide, specify !* to unhide all
         --help                                               Print help information
         --interrupt-ignore-count <INTERRUPT_IGNORE_COUNT>    Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]
     -l, --level <LEVEL>                                      Filtering by level [env: HL_LEVEL=] [possible values: error, warning, info, debug]
@@ -328,7 +327,6 @@ OPTIONS:
         --since <SINCE>                                      Filtering by timestamp >= the value (--time-zone and --local options are honored)
     -t, --time-format <TIME_FORMAT>                          Time format, see https://man7.org/linux/man-pages/man1/date.1.html [env: HL_TIME_FORMAT=] [default: "%y-%m-%d %T.%3N"]
         --theme <THEME>                                      Color theme [env: HL_THEME=] [default: one-dark-green]
-    -u, --unhide <UNHIDE>                                    Unhide fields with the specified keys
         --until <UNTIL>                                      Filtering by timestamp <= the value (--time-zone and --local options are honored)
     -V, --version                                            Print version information
     -Z, --time-zone <TIME_ZONE>                              Time zone name, see column "TZ database name" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones [env: HL_TIME_ZONE=] [default: UTC]

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -126,7 +126,17 @@ impl<N: KeyNormalize> IncludeExcludeKeyFilter<N> {
         self
     }
 
+    pub fn included(mut self) -> Self {
+        self.setting = IncludeExcludeSetting::Include;
+        self
+    }
+
     pub fn exclude(&mut self) -> &mut Self {
+        self.setting = IncludeExcludeSetting::Exclude;
+        self
+    }
+
+    pub fn excluded(mut self) -> Self {
         self.setting = IncludeExcludeSetting::Exclude;
         self
     }


### PR DESCRIPTION
* new: Replaced `--hide`, `--show` and `--unhide` options with a single option `--hide` with advanced query:
  * `header.content-type` to hide field `content-type` inside an object field `header`
  * `*` to hide all
  * `!*` to unhide all
  * `!header.content-type` to unhide field `content-type` inside an object field `header`