### PR TITLE
new: configurable formatting added

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,0 @@
-enum_discrim_align_threshold = 8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "hl"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "atoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -36,6 +36,18 @@ fields:
   # List of exact field names to hide.
   hide: []
 
+# Formatting settings.
+formatting:
+  punctuation:
+    logger-name-separator: ':'
+    field-key-value-separator: ':'
+    string-opening-quote: "'"
+    string-closing-quote: "'"
+    source-location-separator: '@ '
+    hidden-fields-indicator: ' ...'
+    level-left-separator: '|'
+    level-right-separator: '|'
+
 # Number of processing threads, configured automatically based on CPU count if not specified.
 concurrency: ~
 

--- a/etc/defaults/themes/one-dark-green.yaml
+++ b/etc/defaults/themes/one-dark-green.yaml
@@ -11,7 +11,7 @@ elements:
   message:
     foreground: bright-white
   field:
-    foreground: bright-black
+    foreground: default
   key:
     foreground: green
     modes: [underline]

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,10 +11,10 @@ use std::num::NonZeroUsize;
 
 use crate::datefmt::{DateTimeFormat, DateTimeFormatter};
 use crate::error::*;
-use crate::formatting::RecordFormatter;
+use crate::formatting::{RecordFormatter};
 use crate::model::{Filter, Parser, ParserSettings, RawRecord};
 use crate::scanning::{BufFactory, Scanner, Segment, SegmentBufFactory};
-use crate::settings::Fields;
+use crate::settings::{Fields, Formatting};
 use crate::theme::Theme;
 use crate::timezone::Tz;
 use crate::IncludeExcludeKeyFilter;
@@ -29,6 +29,7 @@ pub struct Options {
     pub concurrency: usize,
     pub filter: Filter,
     pub fields: FieldOptions,
+    pub formatting: Formatting,
     pub time_zone: Tz,
     pub hide_empty_fields: bool,
 }
@@ -90,6 +91,7 @@ impl App {
                         ),
                         self.options.hide_empty_fields,
                         self.options.fields.filter.clone(),
+                        self.options.formatting.clone(),
                     )
                     .with_field_unescaping(!self.options.raw_fields);
                     let mut processor = SegmentProcesor::new(&parser, &mut formatter, &self.options.filter);

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,6 +329,7 @@ fn run() -> Result<()> {
             settings: settings.fields,
             filter: Arc::new(fields),
         },
+        formatting: settings.formatting,
         time_zone: tz,
         hide_empty_fields,
     });

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,6 +26,7 @@ pub struct Settings {
     pub concurrency: Option<usize>,
     pub time_format: String,
     pub time_zone: Tz,
+    pub formatting: Formatting,
     pub theme: String,
 }
 
@@ -115,3 +116,38 @@ pub struct Field {
 }
 
 // ---
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Formatting {
+    pub punctuation: Punctuation,
+}
+
+// ---
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct Punctuation {
+    pub logger_name_separator: String,
+    pub field_key_value_separator: String,
+    pub string_opening_quote: String,
+    pub string_closing_quote: String,
+    pub source_location_separator: String,
+    pub hidden_fields_indicator: String,
+    pub level_left_separator: String,
+    pub level_right_separator: String,
+}
+
+impl Default for Punctuation {
+    fn default() -> Self {
+        Self {
+            logger_name_separator: ":".into(),
+            field_key_value_separator: ":".into(),
+            string_opening_quote: "'".into(),
+            string_closing_quote: "'".into(),
+            source_location_separator: "@ ".into(),
+            hidden_fields_indicator: " ...".into(),
+            level_left_separator: "|".into(),
+            level_right_separator: "|".into(),
+        }
+    }
+}


### PR DESCRIPTION
Example
```yaml
# Formatting settings.
formatting:
  punctuation:
    logger-name-separator: ' ‣'
    field-key-value-separator: ':'
    string-opening-quote: "‘"
    string-closing-quote: "’"
    source-location-separator: '→ '
    hidden-fields-indicator: ' ...'
    level-left-separator: '│'
    level-right-separator: '│'
```