### PR TITLE
new: Command line options `-h` and `-l` are now compatible with older versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.20.0-beta.3"
+version = "0.20.0-beta.4"
 dependencies = [
  "anyhow",
  "atoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.20.0-beta.3"
+version = "0.20.0-beta.4"
 edition = "2021"
 build = "build.rs"
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -39,7 +39,7 @@ use crate::input::Input;
 use crate::model::{Parser, ParserSettings, RawRecord};
 use crate::scanning::{Scanner, Segment, SegmentBuf, SegmentBufFactory};
 use crate::settings::PredefinedFields;
-use crate::types::Level;
+use crate::level::Level;
 
 // types
 pub type Writer = dyn Write + Send + Sync;

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,0 +1,84 @@
+// std imports
+use std::cmp::Ord;
+use std::ops::Deref;
+use std::result::Result;
+
+// third-party imports
+use clap::{builder::{EnumValueParser,ValueParserFactory,TypedValueParser}, ValueEnum};
+use enum_map::Enum;
+use serde::{Deserialize, Serialize};
+
+// ---
+
+#[derive(ValueEnum, Clone, Copy, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd, Enum)]
+#[serde(rename_all = "kebab-case")]
+pub enum Level {
+    Error,
+    Warning,
+    Info,
+    Debug,
+}
+
+// ---
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd, Enum)]
+pub struct RelaxedLevel(Level);
+
+impl Into<Level> for RelaxedLevel {
+    fn into(self) -> Level {
+        self.0
+    }
+}
+
+impl Deref for RelaxedLevel {
+    type Target = Level;
+
+    fn deref(&self) -> &Level {
+        &self.0
+    }
+}
+
+
+impl ValueParserFactory for RelaxedLevel {
+    type Parser = LevelValueParser;
+    fn value_parser() -> Self::Parser {
+        LevelValueParser
+    }
+}
+
+// ---
+
+#[derive(Clone, Debug)]
+pub struct LevelValueParser;
+
+impl TypedValueParser for LevelValueParser {
+    type Value = RelaxedLevel;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<RelaxedLevel, clap::Error> {
+        for (level, values) in Self::alternate_values() {
+            if values.iter().cloned().any(|x|value.eq_ignore_ascii_case(x)) {
+                return Ok(RelaxedLevel(*level))
+            }
+        }
+
+        let inner = EnumValueParser::<Level>::new();
+        let val = inner.parse_ref(cmd, arg, value)?;
+        Ok(RelaxedLevel(val))
+    }
+}
+
+impl LevelValueParser {
+    fn alternate_values<'a>() -> &'a [(Level, &'a [&'a str])] {
+        &[
+            (Level::Error, &["err", "e"]),
+            (Level::Warning, &["warn", "wrn", "w"]),
+            (Level::Info, &["inf", "i"]),
+            (Level::Debug, &["dbg", "d"]),
+        ]
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod index;
 pub mod index_capnp;
 pub mod input;
 pub mod iox;
+pub mod level;
 pub mod output;
 pub mod settings;
 pub mod theme;

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,13 +14,14 @@ use wildmatch::WildMatch;
 
 // local imports
 use crate::error::{Error, Result};
+use crate::level;
 use crate::settings::PredefinedFields;
 use crate::timestamp::Timestamp;
-use crate::types::{self, FieldKind};
+use crate::types::{FieldKind};
 
 // ---
 
-pub use types::Level;
+pub use level::Level;
 
 // ---
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize, Serializer};
 
 // local imports
 use crate::error::Error;
-use crate::types::Level;
+use crate::level::Level;
 
 // ---
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -10,13 +10,14 @@ use crate::{
     error::*,
     eseq::{Brightness, Color, ColorCode, Mode, Sequence, StyleCode},
     fmtx::Push,
-    themecfg, types,
+    themecfg, 
+    level,
 };
 
 // ---
 
 pub use themecfg::{Element, ThemeInfo, ThemeOrigin};
-pub use types::Level;
+pub use level::Level;
 
 // ---
 

--- a/src/themecfg.rs
+++ b/src/themecfg.rs
@@ -16,7 +16,7 @@ use rust_embed::RustEmbed;
 use serde::Deserialize;
 
 // local imports
-use crate::{error::*, types::Level};
+use crate::{error::*, level::Level};
 
 // ---
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,48 +1,8 @@
 // std imports
 use std::cmp::Ord;
-use std::result::Result;
-use std::str::FromStr;
 
 // third-party imports
-use clap::ValueEnum;
-use enum_map::Enum;
-use serde::{Deserialize, Serialize};
-
-// local imports
-use crate::error::InvalidLevelError;
-
-// ---
-
-#[derive(ValueEnum, Clone, Copy, Debug, Deserialize, Serialize, Eq, Hash, Ord, PartialEq, PartialOrd, Enum)]
-#[serde(rename_all = "kebab-case")]
-pub enum Level {
-    Error,
-    Warning,
-    Info,
-    Debug,
-}
-
-impl FromStr for Level {
-    type Err = InvalidLevelError;
-
-    fn from_str(s: &str) -> Result<Level, InvalidLevelError> {
-        let matches = |value| s.eq_ignore_ascii_case(value);
-        if matches("e") || matches("error") {
-            Ok(Level::Error)
-        } else if matches("w") || matches("warn") || matches("warning") {
-            Ok(Level::Warning)
-        } else if matches("i") || matches("info") {
-            Ok(Level::Info)
-        } else if matches("d") || matches("debug") {
-            Ok(Level::Debug)
-        } else {
-            Err(InvalidLevelError {
-                value: s.into(),
-                valid_values: vec!["error".into(), "warning".into(), "info".into(), "debug".into()],
-            })
-        }
-    }
-}
+use serde::{Deserialize};
 
 // ---
 


### PR DESCRIPTION
* new: Custom relaxed level parsing when specified on command line
  It now accepts `e`, `w`, `i`, `d` shortcuts as in older versions as well as `err`, `wrn`, `warn`, `inf` and `dbg`
* changed: Renamed `-H | --hide` option back to `-h`, no more shortcut for `--help` flag