### PR TITLE
new: `universal` theme is now default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.20.0-beta.6.6"
+version = "0.20.0-beta.7"
 dependencies = [
  "anyhow",
  "atoi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.20.0-beta.6.6"
+version = "0.20.0-beta.7"
 edition = "2021"
 build = "build.rs"
 

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -59,4 +59,4 @@ formatting:
 concurrency: ~
 
 # Currently selected theme.
-theme: one-dark-green
+theme: universal


### PR DESCRIPTION
Theme `universal` is now set as default because it has greater compatibility with different terminals, in particular it works good both on dark and light terminals.

If you would like to keep `one-dark-green` theme default you can 
* Set environment variable `HL_THEME=one-dark-green`
* Or create/edit configuration file at `~/.config/hl/config.yaml` and set `theme: one-dark-green`
* Or make an alias `alias hl='hl --theme one-dark-green'`