### PR TITLE
new: Added option for raw source message output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -445,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -719,7 +719,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.20.1-alpha.3"
+version = "0.21.0"
 dependencies = [
  "atoi",
  "bincode",
@@ -746,7 +746,7 @@ dependencies = [
  "hex",
  "htp",
  "humantime",
- "itertools",
+ "itertools 0.12.0",
  "itoa",
  "kqueue",
  "notify",
@@ -855,6 +855,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.20.1-alpha.3"
+version = "0.21.0"
 edition = "2021"
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ Options:
       --paging <PAGING>                                  Output paging options [env: HL_PAGING=] [default: auto] [possible values: auto, always, never]
   -P                                                     Handful alias for --paging=never, overrides --paging option
       --theme <THEME>                                    Color theme [env: HL_THEME=] [default: universal]
-  -r, --raw-fields                                       Disable unescaping and prettifying of field values
+  -r, --raw                                              Output raw JSON messages instead of formatter messages, it can be useful for applying filters and saving results in original format
+      --raw-fields                                       Disable unescaping and prettifying of field values
       --interrupt-ignore-count <INTERRUPT_IGNORE_COUNT>  Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]
       --buffer-size <BUFFER_SIZE>                        Buffer size [env: HL_BUFFER_SIZE=] [default: "256 KiB"]
       --max-message-size <MAX_MESSAGE_SIZE>              Maximum message size [env: HL_MAX_MESSAGE_SIZE=] [default: "64 MiB"]

--- a/benches/parse-and-format.rs
+++ b/benches/parse-and-format.rs
@@ -21,7 +21,7 @@ fn benchmark(c: &mut Criterion) {
             c.bench_function(format!("{}/{}", name, theme), |b| {
                 let settings = Settings::default();
                 let parser = Parser::new(ParserSettings::new(&settings.fields.predefined, empty(), false));
-                let mut formatter = RecordFormatter::new(
+                let formatter = RecordFormatter::new(
                     Arc::new(Theme::embedded(theme).unwrap()),
                     DateTimeFormatter::new(
                         LinuxDateFormat::new("%b %d %T.%3N").compile(),
@@ -32,7 +32,7 @@ fn benchmark(c: &mut Criterion) {
                     settings::Formatting::default(),
                 );
                 let filter = Filter::default();
-                let mut processor = SegmentProcessor::new(&parser, &mut formatter, &filter);
+                let mut processor = SegmentProcessor::new(&parser, &formatter, &filter);
                 let mut buf = Vec::new();
                 b.iter(|| {
                     processor.run(record, &mut buf, "", &mut RecordIgnorer {});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod model;
 mod pool;
 mod replay;
 mod scanning;
+mod serdex;
 mod tee;
 
 // conditional public modules

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,12 @@ struct Opt {
     )]
     theme: String,
     //
-    /// Disable unescaping and prettifying of field values.
+    /// Output raw JSON messages instead of formatter messages, it can be useful for applying filters and saving results in original format.
     #[arg(short, long)]
+    raw: bool,
+    //
+    /// Disable unescaping and prettifying of field values.
+    #[arg(long)]
     raw_fields: bool,
     //
     /// Number of interrupts to ignore, i.e. Ctrl-C (SIGINT).
@@ -357,6 +361,7 @@ fn run() -> Result<()> {
     // Create app.
     let app = hl::App::new(hl::Options {
         theme: Arc::new(theme),
+        raw: opt.raw,
         raw_fields: opt.raw_fields,
         time_format,
         buffer_size,

--- a/src/model.rs
+++ b/src/model.rs
@@ -63,6 +63,31 @@ impl<'a> Record<'a> {
 
 // ---
 
+pub trait RecordWithSourceConstructor {
+    fn with_source<'a>(&'a self, source: &'a [u8]) -> RecordWithSource<'a>;
+}
+
+// ---
+
+pub struct RecordWithSource<'a> {
+    pub record: &'a Record<'a>,
+    pub source: &'a [u8],
+}
+
+impl<'a> RecordWithSource<'a> {
+    pub fn new(record: &'a Record<'a>, source: &'a [u8]) -> Self {
+        Self { record, source }
+    }
+}
+
+impl RecordWithSourceConstructor for Record<'_> {
+    fn with_source<'a>(&'a self, source: &'a [u8]) -> RecordWithSource<'a> {
+        RecordWithSource::new(self, source)
+    }
+}
+
+// ---
+
 pub trait RecordFilter {
     fn apply<'a>(&self, record: &'a Record<'a>) -> bool;
 }

--- a/src/serdex.rs
+++ b/src/serdex.rs
@@ -1,0 +1,18 @@
+use serde_json::StreamDeserializer;
+use std::ops::Range;
+
+pub struct StreamDeserializerWithOffsets<'de, R, T>(pub StreamDeserializer<'de, R, T>);
+
+impl<'de, R, T> Iterator for StreamDeserializerWithOffsets<'de, R, T>
+where
+    R: serde_json::de::Read<'de>,
+    T: serde::de::Deserialize<'de>,
+{
+    type Item = serde_json::Result<(T, Range<usize>)>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let start_offset = self.0.byte_offset();
+        self.0
+            .next()
+            .map(|res| res.map(|v| (v, start_offset..self.0.byte_offset())))
+    }
+}


### PR DESCRIPTION
* Added option `--raw` to request output of raw source JSON messages instead of formatted messages.
* Flag `-r` that previously served as a shortcut for `--raw-fields` is now a shortcut for `--raw` option.