### PR TITLE
new: Added support for configuration compatible with ECS log format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools 0.10.5",
+ "itertools",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -445,7 +445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -719,7 +719,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "atoi",
  "bincode",
@@ -746,7 +746,7 @@ dependencies = [
  "hex",
  "htp",
  "humantime",
- "itertools 0.12.0",
+ "itertools",
  "itoa",
  "kqueue",
  "notify",
@@ -855,15 +855,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 build = "build.rs"
 

--- a/etc/defaults/config-ecs.yaml
+++ b/etc/defaults/config-ecs.yaml
@@ -10,45 +10,30 @@ fields:
   # Configuration of the predefined set of fields.
   predefined:
     time:
-      names:
-        [
-          ts,
-          TS,
-          time,
-          TIME,
-          Time,
-          Timestamp,
-          _SOURCE_REALTIME_TIMESTAMP,
-          __REALTIME_TIMESTAMP,
-        ]
+      names: ['@timestamp']
     logger:
-      names: [logger, LOGGER, Logger]
+      names: [log.logger]
     level:
       variants:
-        - names: [level, LEVEL, Level]
+        - names: [log.level]
           values:
-            debug: [debug, Debug]
-            info: [info, information, Information]
-            warning: [warning, Warning, warn]
-            error: [error, Error, err, fatal, critical, panic]
-        - names: [PRIORITY]
-          values:
-            debug: [7]
-            info: [6]
-            warning: [5, 4]
-            error: [3, 2, 1]
+            debug: [debug, dbg, d]
+            info: [info, inf, i, informational]
+            warning: [warning, warn, wrn, w]
+            error: [error, err, fatal, critical, panic, e]
     message:
-      names: [msg, message, MESSAGE, Message]
+      names: [message]
     caller:
-      names: [caller, CALLER, Caller]
+      names: []
     caller-file:
-      names: []
+      names: [log.origin.file.name]
     caller-line:
-      names: []
+      names: [log.origin.file.line]
   # List of wildcard field names to ignore.
   ignore: ['_*']
   # List of exact field names to hide.
-  hide: []
+  hide:
+    - log
 
 # Formatting settings.
 formatting:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -66,12 +66,15 @@ pub struct Fields {
 // ---
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct PredefinedFields {
     pub time: TimeField,
     pub level: LevelField,
     pub message: MessageField,
     pub logger: LoggerField,
     pub caller: CallerField,
+    pub caller_file: CallerFileField,
+    pub caller_line: CallerLineField,
 }
 
 // ---
@@ -109,6 +112,16 @@ pub struct LoggerField(Field);
 
 #[derive(Debug, Serialize, Deserialize, Deref)]
 pub struct CallerField(Field);
+
+// ---
+
+#[derive(Debug, Serialize, Deserialize, Deref)]
+pub struct CallerFileField(Field);
+
+// ---
+
+#[derive(Debug, Serialize, Deserialize, Deref)]
+pub struct CallerLineField(Field);
 
 // ---
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,4 +13,6 @@ pub enum FieldKind {
     Logger,
     Message,
     Caller,
+    CallerFile,
+    CallerLine,
 }


### PR DESCRIPTION
* Added support for predefined field names that can match fields in nested objects when used with dot delimiters.
For example, if `log.origin.file.name' is used for a predefined field name, it will match any of the 
  * `{ "log.origin.file.name": "app.py" }`
  * `{ "log": { "origin.file.name": "app.py" } }`
  * `{ "log": { "origin": {"file.name": "app.py" } } }`
  * `{ "log": { "origin": {"file": {"name": "app.py" } } } }`
  * etc.
* Added predefined `caller-file` and `caller-line` fields for separate processing of file name and line number.

Example output
```
23-11-02 08:09:10.423 |INF| __main__: backup for database bar in foo is already done today application='backup-rds' ecs={ version='1.6.0' } language='python' process={ name='MainProcess' pid=1 thread={ id=140610736142144 name='MainThread' } } ... @ app.py:107
```
Suggested configuration file for ECS logs is [etc/defaults/config-ecs.yaml](https://github.com/pamburus/hl/pull/104/files#diff-30e29bba6d91d0b5ba092f34be1660a8c8a6efff6c3ea51ee7a38f2eaaa1156a)
These settings have not been added to the default configuration because it is not yet clear how they will affect performance.

Closes #97
