### PR TITLE
new: Added option `--allow-prefix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.23.1-beta.2"
+version = "0.23.1"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.23.1-beta.2"
+version = "0.23.1"
 edition = "2021"
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Options:
       --theme <THEME>                                    Color theme [env: HL_THEME=] [default: universal]
   -r, --raw                                              Output raw JSON messages instead of formatter messages, it can be useful for applying filters and saving results in original format
       --raw-fields                                       Disable unescaping and prettifying of field values
+      --allow-prefix                                     Allow non-JSON prefixes before JSON messages [env: HL_ALLOW_PREFIX=]
       --interrupt-ignore-count <INTERRUPT_IGNORE_COUNT>  Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]
       --buffer-size <BUFFER_SIZE>                        Buffer size [env: HL_BUFFER_SIZE=] [default: "256 KiB"]
       --max-message-size <MAX_MESSAGE_SIZE>              Maximum message size [env: HL_MAX_MESSAGE_SIZE=] [default: "64 MiB"]

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -33,7 +33,6 @@ pub struct RawRecordFormatter {}
 impl RecordWithSourceFormatter for RawRecordFormatter {
     fn format_record(&self, buf: &mut Buf, rec: model::RecordWithSource) {
         buf.extend_from_slice(rec.source);
-        buf.push(b'\n');
     }
 }
 
@@ -210,10 +209,6 @@ impl RecordFormatter {
                 });
             };
         });
-        //
-        // eol
-        //
-        buf.push(b'\n')
     }
 
     fn format_field<S: StylingPush<Buf>>(
@@ -520,7 +515,7 @@ mod tests {
                 ]).unwrap(),
                 extrax: Vec::default(),
             }).unwrap(),
-            String::from("\u{1b}[0;2;3m00-01-02 03:04:05.123 \u{1b}[0;36m|\u{1b}[0;95mDBG\u{1b}[0;36m|\u{1b}[0;2;3m \u{1b}[0;2;4mtl:\u{1b}[0;2;3m \u{1b}[0;1;39mtm \u{1b}[0;32mka\u{1b}[0;2m:\u{1b}[0;33m{ \u{1b}[0;32mva\u{1b}[0;2m:\u{1b}[0;33m{ \u{1b}[0;32mkb\u{1b}[0;2m:\u{1b}[0;94m42\u{1b}[0;33m } }\u{1b}[0;2;3m @ tc\u{1b}[0m\n"),
+            String::from("\u{1b}[0;2;3m00-01-02 03:04:05.123 \u{1b}[0;36m|\u{1b}[0;95mDBG\u{1b}[0;36m|\u{1b}[0;2;3m \u{1b}[0;2;4mtl:\u{1b}[0;2;3m \u{1b}[0;1;39mtm \u{1b}[0;32mka\u{1b}[0;2m:\u{1b}[0;33m{ \u{1b}[0;32mva\u{1b}[0;2m:\u{1b}[0;33m{ \u{1b}[0;32mkb\u{1b}[0;2m:\u{1b}[0;94m42\u{1b}[0;33m } }\u{1b}[0;2;3m @ tc\u{1b}[0m"),
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,10 @@ struct Opt {
     #[arg(long)]
     raw_fields: bool,
     //
+    /// Allow non-JSON prefixes before JSON messages.
+    #[arg(long, env = "HL_ALLOW_PREFIX")]
+    allow_prefix: bool,
+    //
     /// Number of interrupts to ignore, i.e. Ctrl-C (SIGINT).
     #[arg(
         long,
@@ -363,6 +367,7 @@ fn run() -> Result<()> {
         theme: Arc::new(theme),
         raw: opt.raw,
         raw_fields: opt.raw_fields,
+        allow_prefix: opt.allow_prefix,
         time_format,
         buffer_size,
         max_message_size,


### PR DESCRIPTION
#### New
* Added option to allow non-JSON prefixes before JSON messages.
  * Command-line option: `--allow-prefix`
  * Environment variable: `HL_ALLOW_PREFIX`
#### Changed
* Prefix mode is now disabled by default since it proved to produce undesired behavior for some input data.

#### Notes
* Changes behavior introduced in #108
* See original feature request: #105