### PR TITLE
new: Added `--query` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.23.2"
+version = "0.24.0-beta.1"
 dependencies = [
  "atoi",
  "bincode",
@@ -752,6 +752,8 @@ dependencies = [
  "nu-ansi-term",
  "num_cpus",
  "once_cell",
+ "pest",
+ "pest_derive",
  "platform-dirs",
  "regex",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.23.2"
+version = "0.24.0-beta.1"
 edition = "2021"
 build = "build.rs"
 
@@ -45,6 +45,8 @@ itoa = { version = "1", default-features = false }
 notify = { version = "6", features = ["macos_kqueue"] }
 num_cpus = "1"
 once_cell = "1"
+pest = "2"
+pest_derive = "2"
 platform-dirs = "0"
 regex = "1"
 rust-embed = "6"

--- a/benches/parse-and-format.rs
+++ b/benches/parse-and-format.rs
@@ -8,9 +8,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 // local imports
 use hl::{
-    app::RecordIgnorer, app::SegmentProcess, settings, timezone::Tz, DateTimeFormatter, Filter,
-    IncludeExcludeKeyFilter, LinuxDateFormat, Parser, ParserSettings, RecordFormatter, SegmentProcessor, Settings,
-    Theme,
+    app::{RecordIgnorer, SegmentProcess, SegmentProcessorOptions},
+    settings,
+    timezone::Tz,
+    DateTimeFormatter, Filter, IncludeExcludeKeyFilter, LinuxDateFormat, Parser, ParserSettings, RecordFormatter,
+    SegmentProcessor, Settings, Theme,
 };
 
 // ---
@@ -33,10 +35,11 @@ fn benchmark(c: &mut Criterion) {
                     settings::Formatting::default(),
                 );
                 let filter = Filter::default();
-                let mut processor = SegmentProcessor::new(&parser, &formatter, &filter, false);
+                let mut processor =
+                    SegmentProcessor::new(&parser, &formatter, &filter, SegmentProcessorOptions::default());
                 let mut buf = Vec::new();
                 b.iter(|| {
-                    processor.run(record, &mut buf, "", &mut RecordIgnorer {});
+                    processor.process(record, &mut buf, "", &mut RecordIgnorer {});
                     buf.clear();
                 });
             });

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 // std imports
 use std::boxed::Box;
 use std::io;
-use std::num::{ParseIntError, TryFromIntError};
+use std::num::{ParseFloatError, ParseIntError, TryFromIntError};
 use std::path::PathBuf;
 use std::sync::mpsc;
 
@@ -9,6 +9,9 @@ use std::sync::mpsc;
 use config::ConfigError;
 use nu_ansi_term::Color;
 use thiserror::Error;
+
+// local imports
+use crate::level;
 
 /// Error is an error which may occur in the application.
 #[derive(Error, Debug)]
@@ -43,7 +46,7 @@ pub enum Error {
     FromUtf8Error(#[from] std::string::FromUtf8Error),
     #[error("failed to parse yaml: {0}")]
     YamlError(#[from] serde_yaml::Error),
-    #[error("wrong field filter format: {0}")]
+    #[error("failed to parse json: {0}")]
     WrongFieldFilter(String),
     #[error("wrong regular expression: {0}")]
     WrongRegularExpression(#[from] regex::Error),
@@ -82,6 +85,12 @@ pub enum Error {
         #[source]
         source: mpsc::RecvTimeoutError,
     },
+    #[error(transparent)]
+    QueryParseError(#[from] pest::error::Error<crate::query::Rule>),
+    #[error(transparent)]
+    LevelParseError(#[from] level::ParseError),
+    #[error(transparent)]
+    ParseFloatError(#[from] ParseFloatError),
 }
 
 /// SizeParseError is an error which may occur when parsing size.

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -514,6 +514,7 @@ mod tests {
                     ("ka", RawValue::from_string(r#"{"va":{"kb":42}}"#.into()).unwrap().as_ref()),
                 ]).unwrap(),
                 extrax: Vec::default(),
+                predefined: heapless::Vec::default(),
             }).unwrap(),
             String::from("\u{1b}[0;2;3m00-01-02 03:04:05.123 \u{1b}[0;36m|\u{1b}[0;95mDBG\u{1b}[0;36m|\u{1b}[0;2;3m \u{1b}[0;2;4mtl:\u{1b}[0;2;3m \u{1b}[0;1;39mtm \u{1b}[0;32mka\u{1b}[0;2m:\u{1b}[0;33m{ \u{1b}[0;32mva\u{1b}[0;2m:\u{1b}[0;33m{ \u{1b}[0;32mkb\u{1b}[0;2m:\u{1b}[0;94m42\u{1b}[0;33m } }\u{1b}[0;2;3m @ tc\u{1b}[0m"),
         );

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,5 +1,6 @@
 // std imports
 use std::cmp::Ord;
+use std::fmt;
 use std::ops::Deref;
 use std::result::Result;
 
@@ -20,6 +21,23 @@ pub enum Level {
     Warning,
     Info,
     Debug,
+}
+
+// ---
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError;
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to parse level")
+    }
+}
+
+impl std::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
 }
 
 // ---
@@ -45,6 +63,18 @@ impl ValueParserFactory for RelaxedLevel {
     type Parser = LevelValueParser;
     fn value_parser() -> Self::Parser {
         LevelValueParser
+    }
+}
+
+impl TryFrom<&str> for RelaxedLevel {
+    type Error = ParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        LevelValueParser::alternate_values()
+            .iter()
+            .find(|(_, values)| values.iter().cloned().any(|x| value.eq_ignore_ascii_case(x)))
+            .map(|(level, _)| RelaxedLevel(*level))
+            .ok_or(ParseError)
     }
 }
 
@@ -77,10 +107,10 @@ impl TypedValueParser for LevelValueParser {
 impl LevelValueParser {
     fn alternate_values<'a>() -> &'a [(Level, &'a [&'a str])] {
         &[
-            (Level::Error, &["err", "e"]),
-            (Level::Warning, &["warn", "wrn", "w"]),
-            (Level::Info, &["inf", "i"]),
-            (Level::Debug, &["dbg", "d"]),
+            (Level::Error, &["error", "err", "e"]),
+            (Level::Warning, &["warning", "warn", "wrn", "w"]),
+            (Level::Info, &["info", "inf", "i"]),
+            (Level::Debug, &["debug", "dbg", "d"]),
         ]
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod input;
 pub mod iox;
 pub mod level;
 pub mod output;
+pub mod query;
 pub mod settings;
 pub mod theme;
 pub mod themecfg;
@@ -40,7 +41,8 @@ pub use app::{App, FieldOptions, Options, SegmentProcessor};
 pub use datefmt::{DateTimeFormatter, LinuxDateFormat};
 pub use filtering::DefaultNormalizing;
 pub use formatting::RecordFormatter;
-pub use model::{FieldFilterSet, Filter, Level, Parser, ParserSettings};
+pub use model::{FieldFilterSet, Filter, Level, Parser, ParserSettings, RecordFilter};
+pub use query::Query;
 pub use settings::Settings;
 pub use theme::Theme;
 
@@ -50,3 +52,4 @@ pub use console::enable_ansi_support;
 // public type aliases
 pub type IncludeExcludeKeyFilter = filtering::IncludeExcludeKeyFilter<DefaultNormalizing>;
 pub type KeyMatchOptions = filtering::MatchOptions<DefaultNormalizing>;
+pub type QueryNone = model::RecordFilterNone;

--- a/src/query.pest
+++ b/src/query.pest
@@ -1,0 +1,111 @@
+input = _{ SOI ~ ws* ~ _expression ~ ws* ~ EOI }
+
+_expression  = _{ _e_or }
+expr_or      =  { _e_and ~ ws* ~ (_or ~ ws* ~ _e_and ~ ws*)+ }
+expr_and     =  { _e_unary ~ ws* ~ (_and ~ ws* ~ _e_unary ~ ws*)+ }
+expr_not     =  { _not ~ ws* ~ _e_unary }
+_e_or        = _{ expr_or | _e_and }
+_e_and       = _{ expr_and | _e_unary }
+_e_unary     = _{ expr_not | primary }
+primary      =  { "(" ~ ws* ~ _expression ~ ws* ~ ")" | term }
+term         =  { level_filter | field_filter }
+level_filter =  { ^"level" ~ ws* ~ _lvl_op ~ ws* ~ level }
+field_filter =  { field_name ~ ws* ~ (_ff_rhs_num_1 | _ff_rhs_num_n | _ff_rhs_str_1 | _ff_rhs_str_n) ~ ws* }
+field_name   = ${ _f_name_short | json_string }
+
+_ff_rhs_num_1 = _{ _ff_num_op_1 ~ ws* ~ number }
+_ff_rhs_num_n = _{ _ff_num_op_n ~ ws* ~ number_set }
+_ff_rhs_str_1 = _{ _ff_str_op_1 ~ ws* ~ string }
+_ff_rhs_str_n = _{ _ff_str_op_n ~ ws* ~ string_set }
+_f_name_short = @{ ("@" | "_" | "-" | "." | LETTER | NUMBER)+ }
+
+level = ${
+    string ~ &punctuation
+}
+
+_or  = _{ ^"or" ~ &punctuation | "||" }
+_and = _{ ^"and" ~ &punctuation | "&&" }
+_not = _{ ^"not" ~ &punctuation | "!" }
+
+_ff_num_op_1 = _{ op_le | op_ge | op_lt | op_gt }
+_ff_num_op_n = _{ op_in | op_not_in }
+_ff_str_op_1 = _{ op_regex_match | op_not_regex_match | op_contain | op_not_contain | op_like | op_not_like | op_equal | op_not_equal }
+_ff_str_op_n = _{ op_in | op_not_in }
+_lvl_op      = _{ op_le | op_ge | op_lt | op_gt | op_equal | op_not_equal }
+string_set   = ${ "(" ~ ws* ~ string ~ (ws* ~ "," ~ ws* ~ string)* ~ ws* ~ ")" }
+number_set   = ${ "(" ~ ws* ~ number ~ (ws* ~ "," ~ ws* ~ number)* ~ ws* ~ ")" }
+
+op_regex_match     = @{
+    "~~="
+  | ^"match" ~ &punctuation
+}
+op_not_regex_match = @{
+    "!~~="
+  | ^"not" ~ ws+ ~ ^"match" ~ &punctuation
+}
+op_contain         = @{
+    "~="
+  | ^"contain" ~ &punctuation
+}
+op_not_contain     = @{
+    "!~="
+  | ^"not" ~ ws+ ~ ^"contain" ~ &punctuation
+}
+op_like            = @{
+    ^"like" ~ &punctuation
+}
+op_not_like        = @{
+    ^"not" ~ ws+ ~ ^"like" ~ &punctuation
+}
+op_equal           = @{
+    "="
+  | ^"eq" ~ &punctuation
+}
+op_not_equal       = @{
+    "!="
+  | ^"not" ~ ws+ ~ ^"eq" ~ &punctuation
+  | ^"ne" ~ &punctuation
+}
+op_in              = @{
+    ^"in" ~ &punctuation
+}
+op_not_in          = @{
+    ^"not" ~ ws+ ~ ^"in" ~ &punctuation
+}
+op_le              = @{
+    "<="
+  | ^"le" ~ &punctuation
+}
+op_lt              = @{
+    "<"
+  | ^"lt" ~ &punctuation
+}
+op_ge              = @{
+    ">="
+  | ^"ge" ~ &punctuation
+}
+op_gt              = @{
+    ">"
+  | ^"gt" ~ &punctuation
+}
+
+punctuation = _{ "(" | ")" | ws | EOI }
+
+string = ${ json_string | simple_string }
+
+json_string       = @{ "\"" ~ json_string_inner ~ "\"" }
+json_string_inner = @{ json_char* }
+json_char         =  {
+    !("\"" | "\\") ~ ANY
+  | "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")
+  | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
+}
+
+simple_string = @{ simple_char+ }
+simple_char   = @{ (LETTER | NUMBER | "@" | "." | "_" | "-" | ":" | "/" | "!" | "#" | "%" | "$" | "*" | "+" | "?") }
+
+number = @{
+    "-"? ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
+}
+
+ws = _{ (" " | "\t" | "\r" | "\n") }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,335 @@
+// third-party imports
+use closure::closure;
+use pest::{iterators::Pair, Parser};
+use pest_derive::Parser;
+use serde_json as json;
+use wildmatch::WildMatch;
+
+// local imports
+use crate::error::Result;
+use crate::level::RelaxedLevel;
+use crate::model::{
+    FieldFilter, FieldFilterKey, Level, NumericOp, Record, RecordFilter, UnaryBoolOp, ValueMatchPolicy,
+};
+use crate::types::FieldKind;
+
+// ---
+
+#[derive(Parser)]
+#[grammar = "query.pest"]
+pub struct QueryParser;
+
+pub type Query = Box<dyn RecordFilter + Sync>;
+
+// ---
+
+pub fn parse(str: &str) -> Result<Query> {
+    let mut pairs = QueryParser::parse(Rule::input, str)?;
+    Ok(expression(pairs.next().unwrap())?)
+}
+
+fn expression(pair: Pair<Rule>) -> Result<Query> {
+    match pair.as_rule() {
+        Rule::expr_or => binary_op::<Or>(pair),
+        Rule::expr_and => binary_op::<And>(pair),
+        Rule::expr_not => not(pair),
+        Rule::primary => primary(pair),
+        _ => unreachable!(),
+    }
+}
+
+fn binary_op<Op: BinaryOp + Sync + 'static>(pair: Pair<Rule>) -> Result<Query> {
+    let mut inner = pair.into_inner();
+    let mut result = expression(inner.next().unwrap())?;
+    for inner in inner {
+        result = Box::new(Op::new(result, expression(inner)?));
+    }
+    Ok(result)
+}
+
+fn not(pair: Pair<Rule>) -> Result<Query> {
+    assert_eq!(pair.as_rule(), Rule::expr_not);
+
+    Ok(Box::new(Not {
+        arg: expression(pair.into_inner().next().unwrap())?,
+    }))
+}
+
+fn primary(pair: Pair<Rule>) -> Result<Query> {
+    assert_eq!(pair.as_rule(), Rule::primary);
+
+    let inner = pair.into_inner().next().unwrap();
+    match inner.as_rule() {
+        Rule::term => term(inner),
+        _ => expression(inner),
+    }
+}
+
+fn term(pair: Pair<Rule>) -> Result<Query> {
+    assert_eq!(pair.as_rule(), Rule::term);
+
+    let inner = pair.into_inner().next().unwrap();
+    match inner.as_rule() {
+        Rule::field_filter => field_filter(inner),
+        Rule::level_filter => level_filter(inner),
+        _ => unreachable!(),
+    }
+}
+
+fn field_filter(pair: Pair<Rule>) -> Result<Query> {
+    assert_eq!(pair.as_rule(), Rule::field_filter);
+
+    let mut inner = pair.into_inner();
+    let lhs = inner.next().unwrap();
+    let op = inner.next().unwrap().as_rule();
+    let rhs = inner.next().unwrap();
+
+    let (match_policy, negated) = match (op, rhs.as_rule()) {
+        (Rule::op_in | Rule::op_not_in, Rule::string_set) => {
+            (ValueMatchPolicy::In(string_set(rhs)?), op == Rule::op_not_in)
+        }
+        (Rule::op_equal | Rule::op_not_equal, Rule::string) => {
+            (ValueMatchPolicy::Exact(string(rhs)?), op == Rule::op_not_equal)
+        }
+        (Rule::op_like | Rule::op_not_like, Rule::string) => (
+            ValueMatchPolicy::WildCard(WildMatch::new(string(rhs)?.as_str())),
+            op == Rule::op_not_like,
+        ),
+        (Rule::op_contain | Rule::op_not_contain, Rule::string) => {
+            (ValueMatchPolicy::SubString(string(rhs)?), op == Rule::op_not_contain)
+        }
+        (Rule::op_regex_match | Rule::op_not_regex_match, Rule::string) => (
+            ValueMatchPolicy::RegularExpression(string(rhs)?.parse()?),
+            op == Rule::op_not_regex_match,
+        ),
+        (Rule::op_in | Rule::op_not_in, Rule::number_set) => (
+            ValueMatchPolicy::Numerically(NumericOp::In(number_set(rhs)?)),
+            op == Rule::op_not_in,
+        ),
+        (Rule::op_equal, Rule::number) => (ValueMatchPolicy::Numerically(NumericOp::Eq(number(rhs)?)), false),
+        (Rule::op_not_equal, Rule::number) => (ValueMatchPolicy::Numerically(NumericOp::Ne(number(rhs)?)), false),
+        (Rule::op_ge, Rule::number) => (ValueMatchPolicy::Numerically(NumericOp::Ge(number(rhs)?)), false),
+        (Rule::op_gt, Rule::number) => (ValueMatchPolicy::Numerically(NumericOp::Gt(number(rhs)?)), false),
+        (Rule::op_le, Rule::number) => (ValueMatchPolicy::Numerically(NumericOp::Le(number(rhs)?)), false),
+        (Rule::op_lt, Rule::number) => (ValueMatchPolicy::Numerically(NumericOp::Lt(number(rhs)?)), false),
+        _ => unreachable!(),
+    };
+
+    Ok(Box::new(FieldFilter::new(
+        field_name(lhs)?.borrowed(),
+        match_policy,
+        if negated {
+            UnaryBoolOp::Negate
+        } else {
+            UnaryBoolOp::None
+        },
+    )))
+}
+
+fn level_filter(pair: Pair<Rule>) -> Result<Query> {
+    assert_eq!(pair.as_rule(), Rule::level_filter);
+
+    let mut inner = pair.into_inner();
+
+    let op = inner.next().unwrap().as_rule();
+    let level = level(inner.next().unwrap())?;
+    Ok(match op {
+        Rule::op_equal => LevelFilter::query(closure!(clone level, | l | l == level)),
+        Rule::op_not_equal => LevelFilter::query(closure!(clone level, | l | l != level)),
+        Rule::op_lt => LevelFilter::query(closure!(clone level, | l | l > level)),
+        Rule::op_le => LevelFilter::query(closure!(clone level, | l | l >= level)),
+        Rule::op_gt => LevelFilter::query(closure!(clone level, | l | l < level)),
+        Rule::op_ge => LevelFilter::query(closure!(clone level, | l | l <= level)),
+        _ => unreachable!(),
+    })
+}
+
+fn string(pair: Pair<Rule>) -> Result<String> {
+    assert_eq!(pair.as_rule(), Rule::string);
+
+    let inner = pair.into_inner().next().unwrap();
+    Ok(match inner.as_rule() {
+        Rule::json_string => json::from_str(inner.as_str())?,
+        Rule::simple_string => inner.as_str().into(),
+        _ => unreachable!(),
+    })
+}
+
+fn string_set(pair: Pair<Rule>) -> Result<Vec<String>> {
+    assert_eq!(pair.as_rule(), Rule::string_set);
+
+    let inner = pair.into_inner();
+    inner.map(|p| string(p)).collect::<Result<Vec<_>>>()
+}
+
+fn number(pair: Pair<Rule>) -> Result<f64> {
+    assert_eq!(pair.as_rule(), Rule::number);
+
+    let inner = pair.as_str();
+    Ok(inner.parse()?)
+}
+
+fn number_set(pair: Pair<Rule>) -> Result<Vec<f64>> {
+    assert_eq!(pair.as_rule(), Rule::number_set);
+
+    let inner = pair.into_inner();
+    inner.map(|p| number(p)).collect::<Result<Vec<_>>>()
+}
+
+fn level(pair: Pair<Rule>) -> Result<Level> {
+    assert_eq!(pair.as_rule(), Rule::level);
+
+    let mut inner = pair.into_inner();
+    let level = string(inner.next().unwrap())?;
+    Ok(RelaxedLevel::try_from(level.as_str())?.into())
+}
+
+fn field_name(pair: Pair<Rule>) -> Result<FieldFilterKey<String>> {
+    assert_eq!(pair.as_rule(), Rule::field_name);
+
+    let inner = pair.into_inner().next().unwrap();
+    Ok(match inner.as_rule() {
+        Rule::json_string => FieldFilterKey::Custom(json::from_str(inner.as_str())?),
+        _ => match inner.as_str() {
+            "message" => FieldFilterKey::Predefined(FieldKind::Message),
+            "logger" => FieldFilterKey::Predefined(FieldKind::Logger),
+            "caller" => FieldFilterKey::Predefined(FieldKind::Caller),
+            _ => FieldFilterKey::Custom(inner.as_str().trim_start_matches('.').to_owned()),
+        },
+    })
+}
+
+// ---
+
+trait BinaryOp: RecordFilter {
+    fn new(lhs: Query, rhs: Query) -> Self;
+}
+
+// ---
+
+struct Or {
+    lhs: Query,
+    rhs: Query,
+}
+
+impl RecordFilter for Or {
+    fn apply<'a>(&self, record: &'a Record<'a>) -> bool {
+        self.lhs.apply(record) || self.rhs.apply(record)
+    }
+}
+
+impl BinaryOp for Or {
+    fn new(lhs: Query, rhs: Query) -> Self {
+        Self { lhs, rhs }
+    }
+}
+
+// ---
+
+struct And {
+    lhs: Query,
+    rhs: Query,
+}
+
+impl RecordFilter for And {
+    fn apply<'a>(&self, record: &'a Record<'a>) -> bool {
+        self.lhs.apply(record) && self.rhs.apply(record)
+    }
+}
+
+impl BinaryOp for And {
+    fn new(lhs: Query, rhs: Query) -> Self {
+        Self { lhs, rhs }
+    }
+}
+
+// ---
+
+struct Not {
+    arg: Query,
+}
+
+impl RecordFilter for Not {
+    fn apply<'a>(&self, record: &'a Record<'a>) -> bool {
+        !self.arg.apply(record)
+    }
+}
+
+// ---
+
+struct LevelFilter<F> {
+    f: F,
+}
+
+impl<F: Fn(Level) -> bool + Send + Sync + 'static> LevelFilter<F> {
+    fn new(f: F) -> Self {
+        Self { f }
+    }
+
+    fn query(f: F) -> Query {
+        Box::new(Self::new(f))
+    }
+}
+
+impl<F: Fn(Level) -> bool> RecordFilter for LevelFilter<F> {
+    fn apply<'a>(&self, record: &'a Record<'a>) -> bool {
+        record.level.map(&self.f).unwrap_or(false)
+    }
+}
+
+// ---
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_or_3() {
+        let mut pairs = QueryParser::parse(Rule::input, ".a=1 or .b=2 or .c=3").unwrap();
+        let p1 = pairs.next().unwrap();
+        assert_eq!(p1.as_rule(), Rule::expr_or);
+        let mut pi1 = p1.into_inner();
+        assert_eq!(pi1.len(), 3);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next(), None);
+    }
+
+    #[test]
+    fn test_and_3() {
+        let mut pairs = QueryParser::parse(Rule::input, ".a=1 and .b=2 and .c=3").unwrap();
+        let p1 = pairs.next().unwrap();
+        assert_eq!(p1.as_rule(), Rule::expr_and);
+        let mut pi1 = p1.into_inner();
+        assert_eq!(pi1.len(), 3);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next(), None);
+    }
+
+    #[test]
+    fn test_or_and() {
+        let mut pairs = QueryParser::parse(Rule::input, ".a=1 or .b=2 and .c=3").unwrap();
+        let p1 = pairs.next().unwrap();
+        assert_eq!(p1.as_rule(), Rule::expr_or);
+        let mut pi1 = p1.into_inner();
+        assert_eq!(pi1.len(), 2);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::expr_and);
+        assert_eq!(pi1.next(), None);
+    }
+
+    #[test]
+    fn test_and_or() {
+        let mut pairs = QueryParser::parse(Rule::input, ".a=1 and .b=2 or .c=3").unwrap();
+        let p1 = pairs.next().unwrap();
+        assert_eq!(p1.as_rule(), Rule::expr_or);
+        let mut pi1 = p1.into_inner();
+        assert_eq!(pi1.len(), 2);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::expr_and);
+        assert_eq!(pi1.next().unwrap().as_rule(), Rule::primary);
+        assert_eq!(pi1.next(), None);
+    }
+}


### PR DESCRIPTION
### Performing complex queries

- Command

    ```
    $ hl my-service.log --query 'level > info or status-code >= 400 or duration > 0.5'
    ```
    Displays messages that either have a level higher than info (i.e. warning or error) or have a status code field with a numeric value >= 400 or a duration field with a numeric value >= 0.5.

- Command

    ```
    $ hl my-service.log -q '(request in (95c72499d9ec, 9697f7aa134f, bc3451d0ad60)) or (method != GET)'
    ```
    Displays all messages that have the 'request' field with one of these values, or the 'method' field with a value other than 'GET'.

- Complete set of supported operators

    * Logical operators
        * Logical conjunction - `and`, `&&`
        * Logical disjunction - `or`, `||`
        * Logical negation - `not`, `!`
    * Comparison operators
        * Equal - `eq`, `=`
        * Not equal - `ne`, `!=`
        * Greater than - `gt`, `>`
        * Greater or equal - `ge`, `>=`
        * Less than - `lt`, `<`
        * Less or equal - `le`, `<=`
    * String matching operators
        * Sub-string check - (`contain`, `~=`), (`not contain`, `!~=`)
        * Wildcard match - (`like`), (`not like`)
            * Wildcard characters are: `*` for zero or more characters and `?` for a single character
        * Regular expression match - (`match`, `~~=`), (`not match`, `!~~=`)
    * Operators with sets
        * Test if value is one of the values in a set - `in (v1, v2)`, `not in (v1, v2)`
    
- Notes

    * Special field names that are reserved for filtering by predefined fields regardless of the actual JSON field names used to load the corresponding value: `level`, `message`, `caller` and `logger`.
    * To address a JSON field with one of these names instead of predefined fields, add a period before its name, i.e., `.level` will perform a match against the "level" JSON field.
    * To address a JSON field by its exact name, use a JSON-formatted string, i.e. `-q '".level" = info'`.
    * To specify special characters in field values, also use a JSON-formatted string, i.e. 
        ```
        $ hl my-service.log -q 'message contain "Error:\nSomething unexpected happened"'
        ```
