### PR TITLE
new: Added `--tail` parameter for `--follow` mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.24.2"
+version = "0.25.0"
 edition = "2021"
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Options:
       --list-themes                                      List available themes and exit
   -s, --sort                                             Sort messages chronologically
   -F, --follow                                           Follow input streams and sort messages chronologically during time frame set by --sync-interval-ms option
+      --tail <TAIL>                                      Number of last messages to preload from each file in --follow mode [default: 10]
       --sync-interval-ms <SYNC_INTERVAL_MS>              Synchronization interval for live streaming mode enabled by --follow option [default: 100]
   -o, --output <OUTPUT>                                  Output file
       --dump-index                                       Dump index metadata and exit

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,6 +66,7 @@ pub struct Options {
     pub input_info: Option<InputInfo>,
     pub dump_index: bool,
     pub app_dirs: Option<AppDirs>,
+    pub tail: u64,
 }
 
 impl Options {
@@ -396,7 +397,7 @@ impl App {
                     if let InputReference::File(filename) = &input_ref { 
                         meta = Some(fs::metadata(filename)?);
                     }
-                    let mut input = Some(input_ref.open()?);
+                    let mut input = Some(input_ref.open_tail(self.options.tail)?);
                     let is_file = |meta: &Option<fs::Metadata>| meta.as_ref().map(|m|m.is_file()).unwrap_or(false);
                     let process = |input: &mut Option<Input>, is_file: bool| {
                         if let Some(input) = input {

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,10 @@ struct Opt {
     #[arg(long, short = 'F')]
     follow: bool,
 
+    /// Number of last messages to preload from each file in --follow mode.
+    #[arg(long, default_value = "10")]
+    tail: u64,
+
     /// Synchronization interval for live streaming mode enabled by --follow option.
     #[arg(long, default_value = "100")]
     sync_interval_ms: u64,
@@ -402,6 +406,7 @@ fn run() -> Result<()> {
         },
         dump_index: opt.dump_index,
         app_dirs: Some(app_dirs),
+        tail: opt.tail,
     });
 
     // Configure input.


### PR DESCRIPTION
Option `--tail` allows to specify number of recent lines that should be preloaded in each file when using `--follow` mode.
Default value is 10.