### PR TITLE
new: Added wildcard support to `--hide` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.25.4-alpha.1"
+version = "0.26.0"
 dependencies = [
  "atoi",
  "bincode",
@@ -1775,8 +1775,7 @@ dependencies = [
 [[package]]
 name = "wildflower"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4138ac28620aa128f691374fdcd36fe5cfc51346f22c51be13887df1146e156e"
+source = "git+https://github.com/pamburus/wildflower.git#9f2ac078689b735bec7e07fbd39cb156237a20a3"
 dependencies = [
  "stable_deref_trait",
  "yoke",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.25.4-alpha.1"
+version = "0.26.0"
 edition = "2021"
 build = "build.rs"
 
@@ -58,7 +58,7 @@ shellwords = "1"
 signal-hook = "0"
 snap = "1"
 thiserror = "1"
-wildflower = "0"
+wildflower = { git = "https://github.com/pamburus/wildflower.git" }
 winapi = {version = "0", features = ["handleapi"]}
 wyhash = "0"
 
@@ -71,7 +71,6 @@ criterion = "0"
 stats_alloc = "0"
 regex = "1"
 wildmatch = "2"
-wildflower = "0"
 
 [profile.release]
 debug = false


### PR DESCRIPTION
### Examples
* `hl -h 'agent-*'` hides all fields with 'agent-' prefix.
* `hl -h '*' -h '!agent-*'` hides all fields except fields with 'agent-' prefix.
* `hl -h 'agent.*' -h '!agent.name'` hides all fields inside 'agent' object except 'name' field.
### Limitations
* Mixed hiding and unhiding with overlapping patterns at the same key path level is not supported and may produce unexpected results. For example, `hl -h 'agent.*' -h '!agent.i*' -h 'agent.?*'`.