### PR TITLE
fix: Fixed tail preloading if input file contains less lines than requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.26.1-alpha.2"
+version = "0.26.2"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.26.1-alpha.2"
+version = "0.26.2"
 edition = "2021"
 build = "build.rs"
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -110,6 +110,7 @@ impl InputReference {
 
             prev_pos = pos;
         }
+        file.seek(SeekFrom::Start(pos as u64))?;
         Ok(())
     }
 }


### PR DESCRIPTION
Fixed `--tail` preloading if input file contains less lines than requested in `--follow` mode.