### PR TITLE
new: Stricter logfmt keys parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.0-beta.1"
+version = "0.27.0-beta.1.1"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.0-beta.1"
+version = "0.27.0-beta.1.1"
 edition = "2021"
 build = "build.rs"
 

--- a/src/logfmt/de.rs
+++ b/src/logfmt/de.rs
@@ -506,9 +506,6 @@ impl<'de> Parser<'de> {
                 b'=' => {
                     break;
                 }
-                b'"' => {
-                    return Err(Error::ExpectedKey);
-                }
                 b'\x00'..=b' ' => {
                     self.key = true;
                     break;
@@ -517,8 +514,11 @@ impl<'de> Parser<'de> {
                     unicode = true;
                     self.index += 1;
                 }
-                _ => {
+                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'.' => {
                     self.index += 1;
+                }
+                _ => {
+                    return Err(Error::UnexpectedByte(c));
                 }
             }
         }


### PR DESCRIPTION
There is no standard for the `logfmt` format, there are just a few implementations that are usually used as a reference.
I haven't seen them all, but the [go implementation](https://pkg.go.dev/github.com/kr/logfmt), which is usually referenced as the source, seems to have an overly simplified definition of the format that behaves strangely. It parses almost any [garbage](https://go.dev/play/p/CcL8I-OEM0T) that doesn't look like a logfmt format.

Also, some log aggregators, such as [AppSignal](https://docs.appsignal.com/logging/formatting/logfmt.html), have restrictions on valid characters in the keys.

I would prefer to leave logs that don't look like `logfmt` or `json` unchanged.
So I decided to limit the allowed characters in `logfmt` keys to letters, digits, dashes, dots, underscores, and unicode characters.