### PR TITLE
new: Added support for floating point timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.0-beta.2.1"
+version = "0.27.0-beta.3"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.0-beta.2.1"
+version = "0.27.0-beta.3"
 edition = "2021"
 build = "build.rs"
 


### PR DESCRIPTION
Added support for timestamps represented as a floating point number of seconds, milliseconds, or microseconds since the Unix epoch.
The units are automatically chosen based on the values. If the value is close enough to Unix epoch, it is assumed to be in seconds.