### PR TITLE
fix: Fixed timestamp parsing in case of negative value and zero fractional part

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.0-beta.3"
+version = "0.27.0-beta.3.1"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.0-beta.3"
+version = "0.27.0-beta.3.1"
 edition = "2021"
 build = "build.rs"
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -36,7 +36,7 @@ impl<'a> Timestamp<'a> {
                     match whole {
                         Self::TS_UNIX_AUTO_S_MIN..=Self::TS_UNIX_AUTO_S_MAX => {
                             let ns = (fractional * 1e9).round() as u32;
-                            let (whole, ns) = if whole < 0 {
+                            let (whole, ns) = if whole < 0 && ns > 0 {
                                 (whole - 1, 1_000_000_000 - ns)
                             } else {
                                 (whole, ns)


### PR DESCRIPTION
Additional fix for #153 and #154.
Fixes floating point timestamp parsing in case of negative value and zero fractional part.
