### PR TITLE
new: Added option to enable or disable quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.0-beta.4.3"
+version = "0.27.0-beta.4.4"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.0-beta.4.3"
+version = "0.27.0-beta.4.4"
 edition = "2021"
 build = "build.rs"
 

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -52,6 +52,7 @@ fields:
 
 # Formatting settings.
 formatting:
+  add-quotes: false
   punctuation:
     logger-name-separator: ':'
     field-key-value-separator: '='

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -355,7 +355,15 @@ impl<'a> FieldFormatter<'a> {
             ValueKind::String(_) => {
                 s.element(Element::String, |s| {
                     s.batch(|buf| {
+                        if self.rf.cfg.add_quotes {
+                            buf.extend_from_slice(self.rf.cfg.punctuation.string_opening_quote.as_bytes())
+                        }
+
                         value.format_as_str(buf);
+
+                        if self.rf.cfg.add_quotes {
+                            buf.extend_from_slice(self.rf.cfg.punctuation.string_closing_quote.as_bytes())
+                        }
                     })
                 });
             }
@@ -437,6 +445,7 @@ mod tests {
             false,
             Arc::new(IncludeExcludeKeyFilter::default()),
             Formatting {
+                add_quotes: false,
                 punctuation: Punctuation::test_default(),
             },
         );

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -134,8 +134,10 @@ pub struct Field {
 // ---
 
 #[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Formatting {
     pub punctuation: Punctuation,
+    pub add_quotes: bool,
 }
 
 // ---


### PR DESCRIPTION
Quotation marks were recently silently removed when `logfmt` format support was added in #147.
Now a configuration file option has been added to enable or disable quoting.
By default it is set to `false` (disabled), but you can manually override the former behavior by setting it to `true` (enabled).
```yaml
# Formatting settings.
formatting:
  add-quotes: false
```