### PR TITLE
new: Added unix timestamp unit option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.0-beta.4.4"
+version = "0.27.0-beta.4.5"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.0-beta.4.4"
+version = "0.27.0-beta.4.5"
 edition = "2021"
 build = "build.rs"
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ bench:
 	@cargo bench
 .PHONY: bench
 
+## Show usage of the binary
+usage: build
+	@env -i ./target/debug/hl --help
+.PHONY: usage
+
 ## Clean build artifacts
 clean:
 	@cargo clean

--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Options:
   -Z, --time-zone <TIME_ZONE>                            Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones [env: HL_TIME_ZONE=] [default: UTC]
   -L, --local                                            Use local time zone, overrides --time-zone option
       --no-local                                         Disable local time zone, overrides --local option
+      --unix-timestamp-unit <UNIX_TIMESTAMP_UNIT>        Unix timestamp unit, [auto, s, ms, us, ns] [env: HL_UNIX_TIMESTAMP_UNIT=] [default: auto] [possible values: auto, s, ms, us, ns]
   -e, --hide-empty-fields                                Hide empty fields, applies for null, string, object and array fields only [env: HL_HIDE_EMPTY_FIELDS=]
   -E, --show-empty-fields                                Show empty fields, overrides --hide-empty-fields option [env: HL_SHOW_EMPTY_FIELDS=]
       --input-info <INPUT_INFO>                          Show input number and/or input filename before each message [default: auto] [possible values: auto, none, full, compact, minimal]
@@ -480,6 +481,7 @@ Options:
   -o, --output <OUTPUT>                                  Output file
       --delimiter <DELIMITER>                            Log message delimiter, [NUL, CR, LF, CRLF] or any custom string
       --dump-index                                       Dump index metadata and exit
+      --debug                                            Print debug error messages that can help with troubleshooting
       --help                                             Print help
   -V, --version                                          Print version
 ```

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -462,7 +462,7 @@ mod tests {
     fn test_nested_objects() {
         assert_eq!(
             format(&Record {
-                ts: Some(Timestamp::new("2000-01-02T03:04:05.123Z", None)),
+                ts: Some(Timestamp::new("2000-01-02T03:04:05.123Z")),
                 message: Some(RawValue::Json(&json_raw_value(r#""tm""#))),
                 level: Some(Level::Debug),
                 logger: Some("tl"),

--- a/src/scanning.rs
+++ b/src/scanning.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 // third-party imports
 use crossbeam_queue::SegQueue;
+use serde::{Deserialize, Serialize};
 
 // local imports
 use crate::error::*;
@@ -36,7 +37,7 @@ impl<D: Delimit> Scanner<D> {
 // ---
 
 /// Defines a token delimiter for Scanner.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Delimiter {
     Byte(u8),
     Bytes(Vec<u8>),


### PR DESCRIPTION
Added `--unix-timestamp-unit` option to allow explicit specification of the unit of Unix timestamps, which can be
* seconds
* milliseconds
* microseconds
* nanoseconds

Automatic detection is used by default.

```
--unix-timestamp-unit <UNIX_TIMESTAMP_UNIT>        Unix timestamp unit, [auto, s, ms, us, ns] [env: HL_UNIX_TIMESTAMP_UNIT=] [default: auto] [possible values: auto, s, ms, us, ns]
```