### PR TITLE
new: Added --input-format option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.0-beta.4.8"
+version = "0.27.0-beta.4.9"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.0-beta.4.8"
+version = "0.27.0-beta.4.9"
 edition = "2021"
 build = "build.rs"
 

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Options:
       --sync-interval-ms <SYNC_INTERVAL_MS>              Synchronization interval for live streaming mode enabled by --follow option [default: 100]
   -o, --output <OUTPUT>                                  Output file
       --delimiter <DELIMITER>                            Log message delimiter, [NUL, CR, LF, CRLF] or any custom string
+      --input-format <INPUT_FORMAT>                      Input format [env: HL_INPUT_FORMAT=] [default: auto] [possible values: auto, json, logfmt]
       --dump-index                                       Dump index metadata and exit
       --debug                                            Print debug error messages that can help with troubleshooting
       --help                                             Print help

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,15 @@ struct Opt {
     #[arg(long, overrides_with = "delimiter")]
     delimiter: Option<String>,
 
+    /// Input format.
+    #[arg(
+        long,
+        env = "HL_INPUT_FORMAT",
+        default_value = "auto",
+        overrides_with = "input_format"
+    )]
+    input_format: InputFormat,
+
     /// Dump index metadata and exit.
     #[arg(long)]
     dump_index: bool,
@@ -254,6 +263,13 @@ enum InputInfoOption {
     Full,
     Compact,
     Minimal,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy)]
+enum InputFormat {
+    Auto,
+    Json,
+    Logfmt,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
@@ -465,6 +481,11 @@ fn run() -> Result<()> {
             InputInfoOption::Full => Some(app::InputInfo::Full),
             InputInfoOption::Compact => Some(app::InputInfo::Compact),
             InputInfoOption::Minimal => Some(app::InputInfo::Minimal),
+        },
+        input_format: match opt.input_format {
+            InputFormat::Auto => None,
+            InputFormat::Json => Some(app::InputFormat::Json),
+            InputFormat::Logfmt => Some(app::InputFormat::Logfmt),
         },
         dump_index: opt.dump_index,
         debug: opt.debug,


### PR DESCRIPTION
Added `--input-format` option.

```
 --input-format <INPUT_FORMAT>                      Input format [env: HL_INPUT_FORMAT=] [default: auto] [possible values: auto, json, logfmt]
 ```

Addresses #36 