### PR TITLE
fix: Fixed invalid utf-8 handling in logfmt format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.2-alpha.3"
+version = "0.27.2-alpha.4"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.2-alpha.3"
+version = "0.27.2-alpha.4"
 edition = "2021"
 build = "build.rs"
 

--- a/src/logfmt/error.rs
+++ b/src/logfmt/error.rs
@@ -29,6 +29,7 @@ pub enum Error {
     UnexpectedControlCharacter,
     UnexpectedByte(u8),
     Custom(String),
+    InvalidUtf8(std::str::Utf8Error),
 }
 
 impl fmt::Display for Error {
@@ -57,6 +58,7 @@ impl fmt::Display for Error {
             Self::UnexpectedControlCharacter => f.write_str("unexpected control character"),
             Self::UnexpectedByte(byte) => write!(f, "unexpected byte: {}", byte),
             Self::Custom(msg) => f.write_str(msg),
+            Self::InvalidUtf8(err) => write!(f, "invalid utf-8: {}", err),
         }
     }
 }


### PR DESCRIPTION
Lines with invalid utf-8 encoding are now excluded from parsing.
They are displayed as is in default mode, and are completely ignored in `--sort` mode.