### PR TITLE
new: Enabled quotes for strings by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.3-alpha.2"
+version = "0.27.3-alpha.3"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.3-alpha.2"
+version = "0.27.3-alpha.3"
 edition = "2021"
 build = "build.rs"
 

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -52,7 +52,7 @@ fields:
 
 # Formatting settings.
 formatting:
-  add-quotes: false
+  add-quotes: true
   punctuation:
     logger-name-separator: ':'
     field-key-value-separator: '='


### PR DESCRIPTION
Enabled quotes for strings by default, as was the case before release 1.27.0, to avoid unreadable text when using spaces.

Automatic usage of quotes will be implemented soon.