### PR TITLE
new: Minor improvements in "universal", "universal-blue" and "neutral" themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.27.3-alpha.4"
+version = "0.27.3-alpha.5"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ categories = ["command-line-utilities"]
 description = "Utility for viewing json-formatted log files."
 keywords = ["cli", "human", "log"]
 name = "hl"
-version = "0.27.3-alpha.4"
+version = "0.27.3-alpha.5"
 edition = "2021"
 build = "build.rs"
 

--- a/etc/defaults/themes/neutral.yaml
+++ b/etc/defaults/themes/neutral.yaml
@@ -28,7 +28,7 @@ elements:
   number:
     foreground: default
   boolean:
-    foreground: yellow
+    foreground: default
   'null':
     foreground: bright-red
 levels:

--- a/etc/defaults/themes/universal-blue.yaml
+++ b/etc/defaults/themes/universal-blue.yaml
@@ -9,6 +9,7 @@ elements:
     modes: [faint, italic]
   level:
     foreground: default
+    modes: [faint]
   message:
     foreground: default
     modes: [bold]

--- a/etc/defaults/themes/universal.yaml
+++ b/etc/defaults/themes/universal.yaml
@@ -9,6 +9,7 @@ elements:
     modes: [faint, italic]
   level:
     foreground: default
+    modes: [faint]
   message:
     foreground: default
     modes: [bold]


### PR DESCRIPTION
Changed level separator style in "universal", "universal-blue" themes to "faint".
Changed boolean value color to "default" in  "neutral" theme.