### PR TITLE
new: All options are now logically grouped in the help output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.28.1-alpha.5"
+version = "0.28.1-alpha.6"
 
 [[package]]
 name = "enum-map"
@@ -757,7 +757,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.28.1-alpha.5"
+version = "0.28.1-alpha.6"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.28.1-alpha.5"
+version = "0.28.1-alpha.6"
 edition = "2021"
 license = "MIT"
 
 [package]
 name = "hl"
-description = "Utility for viewing json-formatted log files"
+description = "JSON and logfmt log converter to human readable representation"
 categories = ["command-line-utilities"]
 keywords = ["cli", "human", "log"]
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -458,45 +458,53 @@ Arguments:
   [FILE]...  Files to process
 
 Options:
-  -c, --color [<WHEN>]                   Color output options [env: HL_COLOR=] [default: auto] [possible values: auto, always, never]
-      --paging <WHEN>                    Output paging options [env: HL_PAGING=] [default: auto] [possible values: auto, always, never]
-  -P                                     Handful alias for --paging=never, overrides --paging option
-      --theme <THEME>                    Color theme [env: HL_THEME=] [default: universal]
-  -r, --raw                              Output raw source messages instead of formatter messages, it can be useful for applying filters and saving results in original format
-      --no-raw                           Disable raw source messages output, overrides --raw option
-      --raw-fields                       Disable unescaping and prettifying of field values
-      --allow-prefix                     Allow non-JSON prefixes before JSON messages [env: HL_ALLOW_PREFIX=]
-      --interrupt-ignore-count <N>       Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]
-      --buffer-size <SIZE>               Buffer size [env: HL_BUFFER_SIZE=] [default: "256 KiB"]
-      --max-message-size <SIZE>          Maximum message size [env: HL_MAX_MESSAGE_SIZE=] [default: "64 MiB"]
-  -C, --concurrency <N>                  Number of processing threads [env: HL_CONCURRENCY=]
-  -f, --filter <FILTER>                  Filtering by field values in one of forms [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v'] where ~ does substring match and ~~ does regular expression match
-  -q, --query <QUERY>                    Custom query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc
-  -h, --hide <KEY>                       Hide or reveal fields with the specified keys, prefix with ! to reveal, specify '!*' to reveal all
-  -l, --level <LEVEL>                    Filtering by level [env: HL_LEVEL=]
-      --since <TIME>                     Filtering by timestamp >= the value (--time-zone and --local options are honored)
-      --until <TIME>                     Filtering by timestamp <= the value (--time-zone and --local options are honored)
-  -t, --time-format <FORMAT>             Time format, see https://man7.org/linux/man-pages/man1/date.1.html [env: HL_TIME_FORMAT=] [default: "%b %d %T.%3N"]
-  -Z, --time-zone <TZ>                   Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones [env: HL_TIME_ZONE=] [default: UTC]
-  -L, --local                            Use local time zone, overrides --time-zone option
-      --no-local                         Disable local time zone, overrides --local option
-      --unix-timestamp-unit <UNIT>       Unix timestamp unit [env: HL_UNIX_TIMESTAMP_UNIT=] [default: auto] [possible values: auto, s, ms, us, ns]
-  -e, --hide-empty-fields                Hide empty fields, applies for null, string, object and array fields only [env: HL_HIDE_EMPTY_FIELDS=]
-  -E, --show-empty-fields                Show empty fields, overrides --hide-empty-fields option [env: HL_SHOW_EMPTY_FIELDS=]
-      --input-info <VARIANT>             Show input number and/or input filename before each message [default: auto] [possible values: auto, none, full, compact, minimal]
-      --list-themes                      List available themes and exit
   -s, --sort                             Sort messages chronologically
   -F, --follow                           Follow input streams and sort messages chronologically during time frame set by --sync-interval-ms option
       --tail <N>                         Number of last messages to preload from each file in --follow mode [default: 10]
       --sync-interval-ms <MILLISECONDS>  Synchronization interval for live streaming mode enabled by --follow option [default: 100]
-  -o, --output <FILE>                    Output file
-      --delimiter <DELIMITER>            Log message delimiter, [NUL, CR, LF, CRLF] or any custom string
-      --input-format <FORMAT>            Input format [env: HL_INPUT_FORMAT=] [default: auto] [possible values: auto, json, logfmt]
-      --dump-index                       Dump index metadata and exit
-      --debug                            Print debug error messages that can help with troubleshooting
-      --shell-completions <SHELL>        Print shell auto-completion script and exit [possible values: bash, elvish, fish, powershell, zsh]
+      --paging <WHEN>                    Control pager usage (HL_PAGER or PAGER) [env: HL_PAGING=] [default: auto] [possible values: auto, always, never]
+  -P                                     Handful alias for --paging=never, overrides --paging option
       --help                             Print help
   -V, --version                          Print version
+
+Filtering Options:
+  -l, --level <LEVEL>    Filter messages by level [env: HL_LEVEL=]
+      --since <TIME>     Filter messages by timestamp >= <TIME> (--time-zone and --local options are honored)
+      --until <TIME>     Filter messages by timestamp <= <TIME> (--time-zone and --local options are honored)
+  -f, --filter <FILTER>  Filter messages by field values [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v'] where ~ does substring match and ~~ does regular expression match
+  -q, --query <QUERY>    Filter using query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc
+
+Output Options:
+  -c, --color [<WHEN>]        Color output control [env: HL_COLOR=] [default: auto] [possible values: auto, always, never]
+      --theme <THEME>         Color theme [env: HL_THEME=] [default: universal]
+  -r, --raw                   Output raw source messages instead of formatted messages, which can be useful for applying filters and saving results in their original format
+      --no-raw                Disable raw source messages output, overrides --raw option
+      --raw-fields            Output field values as is, without unescaping or prettifying
+  -h, --hide <KEY>            Hide or reveal fields with the specified keys, prefix with ! to reveal, specify '!*' to reveal all
+  -t, --time-format <FORMAT>  Time format, see https://man7.org/linux/man-pages/man1/date.1.html [env: HL_TIME_FORMAT=] [default: "%b %d %T.%3N"]
+  -Z, --time-zone <TZ>        Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones [env: HL_TIME_ZONE=] [default: UTC]
+  -L, --local                 Use local time zone, overrides --time-zone option
+      --no-local              Disable local time zone, overrides --local option
+  -e, --hide-empty-fields     Hide empty fields, applies for null, string, object and array fields only [env: HL_HIDE_EMPTY_FIELDS=]
+  -E, --show-empty-fields     Show empty fields, overrides --hide-empty-fields option [env: HL_SHOW_EMPTY_FIELDS=]
+      --input-info <VARIANT>  Show input number and/or input filename before each message [default: auto] [possible values: auto, none, full, compact, minimal]
+  -o, --output <FILE>         Output file
+
+Input Options:
+      --input-format <FORMAT>       Input format [env: HL_INPUT_FORMAT=] [default: auto] [possible values: auto, json, logfmt]
+      --unix-timestamp-unit <UNIT>  Unix timestamp unit [env: HL_UNIX_TIMESTAMP_UNIT=] [default: auto] [possible values: auto, s, ms, us, ns]
+      --allow-prefix                Allow non-JSON prefixes before JSON messages [env: HL_ALLOW_PREFIX=]
+      --delimiter <DELIMITER>       Log message delimiter, [NUL, CR, LF, CRLF] or any custom string
+
+Advanced Options:
+      --interrupt-ignore-count <N>  Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]
+      --buffer-size <SIZE>          Buffer size [env: HL_BUFFER_SIZE=] [default: "256 KiB"]
+      --max-message-size <SIZE>     Maximum message size [env: HL_MAX_MESSAGE_SIZE=] [default: "64 MiB"]
+  -C, --concurrency <N>             Number of processing threads [env: HL_CONCURRENCY=]
+      --shell-completions <SHELL>   Print shell auto-completion script and exit [possible values: bash, elvish, fish, powershell, zsh]
+      --list-themes                 Print available themes and exit
+      --dump-index                  Print debug index metadata (in --sort mode) and exit
+      --debug                       Print debug error messages that can help with troubleshooting
 ```
 
 ## Performance

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,198 +19,6 @@ use crate::{
 #[derive(Parser)]
 #[clap(version, disable_help_flag = true)]
 pub struct Opt {
-    /// Color output options.
-    #[arg(
-        long,
-        short,
-        default_value = "auto",
-        env = "HL_COLOR",
-        overrides_with = "color",
-        default_missing_value = "always",
-        num_args = 0..=1,
-        value_name = "WHEN",
-        value_enum
-    )]
-    pub color: ColorOption,
-
-    /// Output paging options.
-    #[arg(
-        long,
-        default_value = "auto",
-        env = "HL_PAGING",
-        overrides_with = "paging",
-        value_name = "WHEN",
-        value_enum
-    )]
-    pub paging: PagingOption,
-
-    /// Handful alias for --paging=never, overrides --paging option.
-    #[arg(short = 'P')]
-    pub paging_never: bool,
-
-    /// Color theme.
-    #[arg(
-        long,
-        default_value_t = config::get().theme.clone(),
-        env = "HL_THEME",
-        overrides_with="theme"
-    )]
-    pub theme: String,
-
-    /// Output raw source messages instead of formatter messages, it can be useful for applying filters and saving results in original format.
-    #[arg(short, long, overrides_with = "raw")]
-    pub raw: bool,
-
-    /// Disable raw source messages output, overrides --raw option.
-    #[arg(long, overrides_with = "raw")]
-    _no_raw: bool,
-
-    /// Disable unescaping and prettifying of field values.
-    #[arg(long, overrides_with = "raw_fields")]
-    pub raw_fields: bool,
-
-    /// Allow non-JSON prefixes before JSON messages.
-    #[arg(long, env = "HL_ALLOW_PREFIX", overrides_with = "allow_prefix")]
-    pub allow_prefix: bool,
-
-    /// Number of interrupts to ignore, i.e. Ctrl-C (SIGINT).
-    #[arg(
-        long,
-        default_value = "3",
-        env = "HL_INTERRUPT_IGNORE_COUNT",
-        overrides_with = "interrupt_ignore_count",
-        value_name = "N"
-    )]
-    pub interrupt_ignore_count: usize,
-
-    /// Buffer size.
-    #[arg(
-        long,
-        default_value = "256 KiB",
-        env="HL_BUFFER_SIZE",
-        value_parser = parse_non_zero_size,
-        overrides_with="buffer_size",
-        value_name = "SIZE"
-    )]
-    pub buffer_size: NonZeroUsize,
-
-    /// Maximum message size.
-    #[arg(
-        long,
-        default_value = "64 MiB",
-        env="HL_MAX_MESSAGE_SIZE",
-        value_parser = parse_non_zero_size,
-        overrides_with="max_message_size",
-        value_name = "SIZE"
-    )]
-    pub max_message_size: NonZeroUsize,
-
-    /// Number of processing threads.
-    #[arg(
-        long,
-        short = 'C',
-        env = "HL_CONCURRENCY",
-        overrides_with = "concurrency",
-        value_name = "N"
-    )]
-    pub concurrency: Option<usize>,
-
-    /// Filtering by field values in one of forms [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v'] where ~ does substring match and ~~ does regular expression match.
-    #[arg(short, long, number_of_values = 1)]
-    pub filter: Vec<String>,
-
-    /// Custom query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc.
-    #[arg(short, long, number_of_values = 1)]
-    pub query: Vec<String>,
-
-    /// Hide or reveal fields with the specified keys, prefix with ! to reveal, specify '!*' to reveal all.
-    #[arg(long, short = 'h', number_of_values = 1, value_name = "KEY")]
-    pub hide: Vec<String>,
-
-    /// Filtering by level.
-    #[arg(short, long, env = "HL_LEVEL", overrides_with="level", ignore_case=true, value_parser = LevelValueParser)]
-    #[arg(value_enum)]
-    pub level: Option<RelaxedLevel>,
-
-    /// Filtering by timestamp >= the value (--time-zone and --local options are honored).
-    #[arg(long, allow_hyphen_values = true, overrides_with = "since", value_name = "TIME")]
-    pub since: Option<String>,
-
-    /// Filtering by timestamp <= the value (--time-zone and --local options are honored).
-    #[arg(long, allow_hyphen_values = true, overrides_with = "until", value_name = "TIME")]
-    pub until: Option<String>,
-
-    /// Time format, see https://man7.org/linux/man-pages/man1/date.1.html.
-    #[arg(
-        short,
-        long,
-        env="HL_TIME_FORMAT",
-        default_value_t = config::get().time_format.clone(),
-        overrides_with = "time_format",
-        value_name = "FORMAT",
-    )]
-    pub time_format: String,
-
-    /// Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
-    #[arg(
-        long,
-        short = 'Z',
-        env="HL_TIME_ZONE",
-        default_value = config::get().time_zone.name(),
-        overrides_with="time_zone",
-        value_name = "TZ"
-    )]
-    pub time_zone: chrono_tz::Tz,
-
-    /// Use local time zone, overrides --time-zone option.
-    #[arg(long, short = 'L', overrides_with = "local")]
-    pub local: bool,
-
-    /// Disable local time zone, overrides --local option.
-    #[arg(long, overrides_with = "local")]
-    _no_local: bool,
-
-    /// Unix timestamp unit.
-    #[arg(
-        long,
-        default_value = "auto",
-        overrides_with = "unix_timestamp_unit",
-        env = "HL_UNIX_TIMESTAMP_UNIT",
-        value_name = "UNIT"
-    )]
-    pub unix_timestamp_unit: UnixTimestampUnit,
-
-    /// Files to process
-    #[arg(name = "FILE")]
-    pub files: Vec<PathBuf>,
-
-    /// Hide empty fields, applies for null, string, object and array fields only.
-    #[arg(
-        long,
-        short = 'e',
-        env = "HL_HIDE_EMPTY_FIELDS",
-        overrides_with = "hide_empty_fields"
-    )]
-    pub hide_empty_fields: bool,
-
-    /// Show empty fields, overrides --hide-empty-fields option.
-    #[arg(
-        long,
-        short = 'E',
-        env = "HL_SHOW_EMPTY_FIELDS",
-        overrides_with = "show_empty_fields"
-    )]
-    pub show_empty_fields: bool,
-
-    /// Show input number and/or input filename before each message.
-    #[arg(long, default_value = "auto", overrides_with = "input_info", value_name = "VARIANT")]
-    #[arg(value_enum)]
-    pub input_info: InputInfoOption,
-
-    /// List available themes and exit.
-    #[arg(long)]
-    pub list_themes: bool,
-
     /// Sort messages chronologically.
     #[arg(long, short = 's', overrides_with = "sort")]
     pub sort: bool,
@@ -232,13 +40,178 @@ pub struct Opt {
     )]
     pub sync_interval_ms: u64,
 
-    /// Output file.
-    #[arg(long, short = 'o', overrides_with = "output", value_name = "FILE")]
-    pub output: Option<String>,
+    /// Control pager usage (HL_PAGER or PAGER).
+    #[arg(
+        long,
+        default_value = "auto",
+        env = "HL_PAGING",
+        overrides_with = "paging",
+        value_name = "WHEN",
+        value_enum
+    )]
+    pub paging: PagingOption,
 
-    /// Log message delimiter, [NUL, CR, LF, CRLF] or any custom string.
-    #[arg(long, overrides_with = "delimiter")]
-    pub delimiter: Option<String>,
+    /// Handful alias for --paging=never, overrides --paging option.
+    #[arg(short = 'P')]
+    pub paging_never: bool,
+
+    /// Filter messages by level.
+    #[arg(
+        short,
+        long,
+        env = "HL_LEVEL",
+        overrides_with="level",
+        ignore_case=true,
+        value_parser = LevelValueParser,
+        value_enum,
+        help_heading = heading::FILTERING
+    )]
+    pub level: Option<RelaxedLevel>,
+
+    /// Filter messages by timestamp >= <TIME> (--time-zone and --local options are honored).
+    #[arg(
+        long,
+        allow_hyphen_values = true,
+        overrides_with = "since",
+        value_name = "TIME",
+        help_heading = heading::FILTERING
+    )]
+    pub since: Option<String>,
+
+    /// Filter messages by timestamp <= <TIME> (--time-zone and --local options are honored).
+    #[arg(
+        long,
+        allow_hyphen_values = true,
+        overrides_with = "until",
+        value_name = "TIME",
+        help_heading = heading::FILTERING
+    )]
+    pub until: Option<String>,
+
+    /// Filter messages by field values
+    /// [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v']
+    /// where ~ does substring match and ~~ does regular expression match.
+    #[arg(short, long, number_of_values = 1, help_heading = heading::FILTERING)]
+    pub filter: Vec<String>,
+
+    /// Filter using query, accepts expressions from --filter
+    /// and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc.
+    #[arg(short, long, number_of_values = 1, help_heading = heading::FILTERING)]
+    pub query: Vec<String>,
+
+    /// Color output control.
+    #[arg(
+        long,
+        short,
+        default_value = "auto",
+        env = "HL_COLOR",
+        overrides_with = "color",
+        default_missing_value = "always",
+        num_args = 0..=1,
+        value_name = "WHEN",
+        value_enum,
+        help_heading = heading::OUTPUT
+    )]
+    pub color: ColorOption,
+
+    /// Color theme.
+    #[arg(
+        long,
+        default_value_t = config::get().theme.clone(),
+        env = "HL_THEME",
+        overrides_with="theme",
+        help_heading = heading::OUTPUT
+    )]
+    pub theme: String,
+
+    /// Output raw source messages instead of formatted messages, which can be useful for applying filters and saving results in their original format.
+    #[arg(short, long, overrides_with = "raw", help_heading = heading::OUTPUT)]
+    pub raw: bool,
+
+    /// Disable raw source messages output, overrides --raw option.
+    #[arg(long, overrides_with = "raw", help_heading = heading::OUTPUT)]
+    _no_raw: bool,
+
+    /// Output field values as is, without unescaping or prettifying.
+    #[arg(long, overrides_with = "raw_fields", help_heading = heading::OUTPUT)]
+    pub raw_fields: bool,
+
+    /// Hide or reveal fields with the specified keys, prefix with ! to reveal, specify '!*' to reveal all.
+    #[arg(
+        long,
+        short = 'h',
+        number_of_values = 1,
+        value_name = "KEY",
+        help_heading = heading::OUTPUT
+    )]
+    pub hide: Vec<String>,
+
+    /// Time format, see https://man7.org/linux/man-pages/man1/date.1.html.
+    #[arg(
+        short,
+        long,
+        env="HL_TIME_FORMAT",
+        default_value_t = config::get().time_format.clone(),
+        overrides_with = "time_format",
+        value_name = "FORMAT",
+        help_heading = heading::OUTPUT
+    )]
+    pub time_format: String,
+
+    /// Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+    #[arg(
+        long,
+        short = 'Z',
+        env="HL_TIME_ZONE",
+        default_value = config::get().time_zone.name(),
+        overrides_with="time_zone",
+        value_name = "TZ",
+        help_heading = heading::OUTPUT
+    )]
+    pub time_zone: chrono_tz::Tz,
+
+    /// Use local time zone, overrides --time-zone option.
+    #[arg(long, short = 'L', overrides_with = "local", help_heading = heading::OUTPUT)]
+    pub local: bool,
+
+    /// Disable local time zone, overrides --local option.
+    #[arg(long, overrides_with = "local", help_heading = heading::OUTPUT)]
+    _no_local: bool,
+
+    /// Hide empty fields, applies for null, string, object and array fields only.
+    #[arg(
+        long,
+        short = 'e',
+        env = "HL_HIDE_EMPTY_FIELDS",
+        overrides_with = "hide_empty_fields",
+        help_heading = heading::OUTPUT
+    )]
+    pub hide_empty_fields: bool,
+
+    /// Show empty fields, overrides --hide-empty-fields option.
+    #[arg(
+        long,
+        short = 'E',
+        env = "HL_SHOW_EMPTY_FIELDS",
+        overrides_with = "show_empty_fields",
+        help_heading = heading::OUTPUT
+    )]
+    pub show_empty_fields: bool,
+
+    /// Show input number and/or input filename before each message.
+    #[arg(
+        long,
+        default_value = "auto",
+        overrides_with = "input_info",
+        value_name = "VARIANT",
+        value_enum,
+        help_heading = heading::OUTPUT
+    )]
+    pub input_info: InputInfoOption,
+
+    /// Output file.
+    #[arg(long, short = 'o', overrides_with = "output", value_name = "FILE", help_heading = heading::OUTPUT)]
+    pub output: Option<String>,
 
     /// Input format.
     #[arg(
@@ -246,25 +219,99 @@ pub struct Opt {
         env = "HL_INPUT_FORMAT",
         default_value = "auto",
         overrides_with = "input_format",
-        value_name = "FORMAT"
+        value_name = "FORMAT",
+        help_heading = heading::INPUT
     )]
     pub input_format: InputFormat,
 
-    /// Dump index metadata and exit.
-    #[arg(long)]
+    /// Unix timestamp unit.
+    #[arg(
+        long,
+        default_value = "auto",
+        overrides_with = "unix_timestamp_unit",
+        env = "HL_UNIX_TIMESTAMP_UNIT",
+        value_name = "UNIT",
+        help_heading = heading::INPUT
+    )]
+    pub unix_timestamp_unit: UnixTimestampUnit,
+
+    /// Allow non-JSON prefixes before JSON messages.
+    #[arg(long, env = "HL_ALLOW_PREFIX", overrides_with = "allow_prefix", help_heading = heading::INPUT)]
+    pub allow_prefix: bool,
+
+    /// Log message delimiter, [NUL, CR, LF, CRLF] or any custom string.
+    #[arg(long, overrides_with = "delimiter", help_heading = heading::INPUT)]
+    pub delimiter: Option<String>,
+
+    /// Number of interrupts to ignore, i.e. Ctrl-C (SIGINT).
+    #[arg(
+        long,
+        default_value = "3",
+        env = "HL_INTERRUPT_IGNORE_COUNT",
+        overrides_with = "interrupt_ignore_count",
+        value_name = "N",
+        help_heading = heading::ADVANCED
+    )]
+    pub interrupt_ignore_count: usize,
+
+    /// Buffer size.
+    #[arg(
+        long,
+        default_value = "256 KiB",
+        env="HL_BUFFER_SIZE",
+        value_parser = parse_non_zero_size,
+        overrides_with="buffer_size",
+        value_name = "SIZE",
+        help_heading = heading::ADVANCED
+    )]
+    pub buffer_size: NonZeroUsize,
+
+    /// Maximum message size.
+    #[arg(
+        long,
+        default_value = "64 MiB",
+        env="HL_MAX_MESSAGE_SIZE",
+        value_parser = parse_non_zero_size,
+        overrides_with="max_message_size",
+        value_name = "SIZE",
+        help_heading = heading::ADVANCED
+    )]
+    pub max_message_size: NonZeroUsize,
+
+    /// Number of processing threads.
+    #[arg(
+        long,
+        short = 'C',
+        env = "HL_CONCURRENCY",
+        overrides_with = "concurrency",
+        value_name = "N",
+        help_heading = heading::ADVANCED
+    )]
+    pub concurrency: Option<usize>,
+
+    /// Print shell auto-completion script and exit.
+    #[arg(long, value_parser = value_parser!(Shell), value_name = "SHELL", help_heading = heading::ADVANCED)]
+    pub shell_completions: Option<Shell>,
+
+    /// Print available themes and exit.
+    #[arg(long, help_heading = heading::ADVANCED)]
+    pub list_themes: bool,
+
+    /// Print debug index metadata (in --sort mode) and exit.
+    #[arg(long, requires = "sort", help_heading = heading::ADVANCED)]
     pub dump_index: bool,
 
     /// Print debug error messages that can help with troubleshooting.
-    #[arg(long)]
+    #[arg(long, help_heading = heading::ADVANCED)]
     pub debug: bool,
-
-    /// Print shell auto-completion script and exit.
-    #[arg(long, value_parser = value_parser!(Shell), value_name = "SHELL")]
-    pub shell_completions: Option<Shell>,
 
     /// Print help.
     #[arg(long, default_value_t = false, action = ArgAction::SetTrue)]
     pub help: bool,
+
+    /// Files to process
+    #[arg(name = "FILE")]
+    pub files: Vec<PathBuf>,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]
@@ -304,6 +351,13 @@ pub enum UnixTimestampUnit {
     Ms,
     Us,
     Ns,
+}
+
+mod heading {
+    pub const FILTERING: &str = "Filtering Options";
+    pub const INPUT: &str = "Input Options";
+    pub const OUTPUT: &str = "Output Options";
+    pub const ADVANCED: &str = "Advanced Options";
 }
 
 fn parse_size(s: &str) -> std::result::Result<usize, SizeParseError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn run() -> Result<()> {
     let time_format = LinuxDateFormat::new(&opt.time_format).compile();
     // Configure filter.
     let filter = hl::Filter {
-        fields: hl::FieldFilterSet::new(opt.filter)?,
+        fields: hl::FieldFilterSet::new(&opt.filter)?,
         level: opt.level.map(|x| x.into()),
         since: if let Some(v) = &opt.since {
             Some(parse_time(v, &tz, &time_format)?.with_timezone(&Utc))
@@ -142,7 +142,7 @@ fn run() -> Result<()> {
     let buffer_size = std::cmp::min(max_message_size, opt.buffer_size);
 
     let mut query: Option<Query> = None;
-    for q in opt.query {
+    for q in &opt.query {
         let right = Query::parse(&q)?;
         if let Some(left) = query {
             query = Some(left.and(right));


### PR DESCRIPTION
```
JSON and logfmt log converter to human readable representation

Usage: hl [OPTIONS] [FILE]...

Arguments:
  [FILE]...  Files to process

Options:
  -s, --sort                             Sort messages chronologically
  -F, --follow                           Follow input streams and sort messages chronologically during time frame set by --sync-interval-ms option
      --tail <N>                         Number of last messages to preload from each file in --follow mode [default: 10]
      --sync-interval-ms <MILLISECONDS>  Synchronization interval for live streaming mode enabled by --follow option [default: 100]
      --paging <WHEN>                    Control pager usage (HL_PAGER or PAGER) [env: HL_PAGING=] [default: auto] [possible values: auto, always, never]
  -P                                     Handful alias for --paging=never, overrides --paging option
      --help                             Print help
  -V, --version                          Print version

Filtering Options:
  -l, --level <LEVEL>    Filter messages by level [env: HL_LEVEL=]
      --since <TIME>     Filter messages by timestamp >= <TIME> (--time-zone and --local options are honored)
      --until <TIME>     Filter messages by timestamp <= <TIME> (--time-zone and --local options are honored)
  -f, --filter <FILTER>  Filter messages by field values [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v'] where ~ does substring match and ~~ does regular expression match
  -q, --query <QUERY>    Filter using query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc

Output Options:
  -c, --color [<WHEN>]        Color output control [env: HL_COLOR=] [default: auto] [possible values: auto, always, never]
      --theme <THEME>         Color theme [env: HL_THEME=] [default: universal]
  -r, --raw                   Output raw source messages instead of formatted messages, which can be useful for applying filters and saving results in their original format
      --no-raw                Disable raw source messages output, overrides --raw option
      --raw-fields            Output field values as is, without unescaping or prettifying
  -h, --hide <KEY>            Hide or reveal fields with the specified keys, prefix with ! to reveal, specify '!*' to reveal all
  -t, --time-format <FORMAT>  Time format, see https://man7.org/linux/man-pages/man1/date.1.html [env: HL_TIME_FORMAT=] [default: "%b %d %T.%3N"]
  -Z, --time-zone <TZ>        Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones [env: HL_TIME_ZONE=] [default: UTC]
  -L, --local                 Use local time zone, overrides --time-zone option
      --no-local              Disable local time zone, overrides --local option
  -e, --hide-empty-fields     Hide empty fields, applies for null, string, object and array fields only [env: HL_HIDE_EMPTY_FIELDS=]
  -E, --show-empty-fields     Show empty fields, overrides --hide-empty-fields option [env: HL_SHOW_EMPTY_FIELDS=]
      --input-info <VARIANT>  Show input number and/or input filename before each message [default: auto] [possible values: auto, none, full, compact, minimal]
  -o, --output <FILE>         Output file

Input Options:
      --input-format <FORMAT>       Input format [env: HL_INPUT_FORMAT=] [default: auto] [possible values: auto, json, logfmt]
      --unix-timestamp-unit <UNIT>  Unix timestamp unit [env: HL_UNIX_TIMESTAMP_UNIT=] [default: auto] [possible values: auto, s, ms, us, ns]
      --allow-prefix                Allow non-JSON prefixes before JSON messages [env: HL_ALLOW_PREFIX=]
      --delimiter <DELIMITER>       Log message delimiter, [NUL, CR, LF, CRLF] or any custom string

Advanced Options:
      --interrupt-ignore-count <N>  Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]
      --buffer-size <SIZE>          Buffer size [env: HL_BUFFER_SIZE=] [default: "256 KiB"]
      --max-message-size <SIZE>     Maximum message size [env: HL_MAX_MESSAGE_SIZE=] [default: "64 MiB"]
  -C, --concurrency <N>             Number of processing threads [env: HL_CONCURRENCY=]
      --shell-completions <SHELL>   Print shell auto-completion script and exit [possible values: bash, elvish, fish, powershell, zsh]
      --list-themes                 Print available themes and exit
      --dump-index                  Print debug index metadata (in --sort mode) and exit
      --debug                       Print debug error messages that can help with troubleshooting
```