### PR TITLE
fix: Partially reverted #220 due to unexpected breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.28.1-alpha.6"
+version = "0.28.1-alpha.7"
 
 [[package]]
 name = "enum-map"
@@ -757,7 +757,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.28.1-alpha.6"
+version = "0.28.1-alpha.7"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.28.1-alpha.6"
+version = "0.28.1-alpha.7"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -475,7 +475,8 @@ Filtering Options:
   -q, --query <QUERY>    Filter using query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc
 
 Output Options:
-  -c, --color [<WHEN>]        Color output control [env: HL_COLOR=] [default: auto] [possible values: auto, always, never]
+      --color [<WHEN>]        Color output control [env: HL_COLOR=] [default: auto] [possible values: auto, always, never]
+  -c                          Handful alias for --color=always, overrides --color option
       --theme <THEME>         Color theme [env: HL_THEME=] [default: universal]
   -r, --raw                   Output raw source messages instead of formatted messages, which can be useful for applying filters and saving results in their original format
       --no-raw                Disable raw source messages output, overrides --raw option

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,10 +102,9 @@ pub struct Opt {
     /// Color output control.
     #[arg(
         long,
-        short,
         default_value = "auto",
         env = "HL_COLOR",
-        overrides_with = "color",
+        overrides_with_all = ["color", "color_always"],
         default_missing_value = "always",
         num_args = 0..=1,
         value_name = "WHEN",
@@ -113,6 +112,14 @@ pub struct Opt {
         help_heading = heading::OUTPUT
     )]
     pub color: ColorOption,
+
+    /// Handful alias for --color=always, overrides --color option.
+    #[arg(
+        short,
+        overrides_with_all = ["color", "color_always"],
+        help_heading = heading::OUTPUT
+    )]
+    pub color_always: bool,
 
     /// Color theme.
     #[arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,12 @@ fn run() -> Result<()> {
     };
 
     // Configure color scheme.
-    let use_colors = match opt.color {
+    let color = if opt.color_always {
+        cli::ColorOption::Always
+    } else {
+        opt.color
+    };
+    let use_colors = match color {
         cli::ColorOption::Auto => stdout().is_terminal() && color_supported,
         cli::ColorOption::Always => true,
         cli::ColorOption::Never => false,


### PR DESCRIPTION
Now `-c` is a flag as it was before, it can be used in a group of flags combined together, and it overrides `--color`.
Additionally, `-c` can now be overridden by `--color`.