### PR TITLE
new: Added support for theme preview with `fzf`

### DIFF
--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,4 +1,10 @@
 [coverage]
 workspace = true
 all-features = true
-exclude-files = ["src/*_capnp.rs", "src/cli.rs", "src/config.rs", "src/main.rs"]
+exclude-files = [
+    "src/*_capnp.rs",
+    "src/cli.rs",
+    "src/config.rs",
+    "src/main.rs",
+    "src/themecfg.rs",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.28.1-alpha.7"
+version = "0.28.1-alpha.8"
 
 [[package]]
 name = "enum-map"
@@ -757,7 +757,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.28.1-alpha.7"
+version = "0.28.1-alpha.8"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.28.1-alpha.7"
+version = "0.28.1-alpha.8"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,12 @@ See other [screenshots](https://github.com/pamburus/hl-extra/tree/90be58af2fb91d
 * Using environment variable, i.e. `HL_THEME=classic`, overrides the value specified in configuration file.
 * Using command-line argument, i.e. `--theme classic`, overrides all other values.
 
+#### Selecting themes with preview
+To select themes with preview [fzf](https://github.com/junegunn/fzf) tool can be used like this:
+```bash
+hl --list-themes | fzf --preview-window="top,80%" --preview="head -n 100 example.log | hl -c --theme {}"
+```
+
 #### Custom themes
 - Custom themes are automatically loaded when found in a predefined platform-specific location.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,15 @@ fn run() -> Result<()> {
                 ThemeOrigin::Stock => "stock",
                 ThemeOrigin::Custom => "custom",
             };
-            println!("{}:", origin);
+            if stdout().is_terminal() {
+                println!("{}:", origin);
+            }
             for (name, _) in group {
-                println!("  {}", name);
+                if stdout().is_terminal() {
+                    println!("  - {}", name);
+                } else {
+                    println!("{}", name);
+                }
             }
         }
         return Ok(());

--- a/src/themecfg.rs
+++ b/src/themecfg.rs
@@ -63,8 +63,17 @@ impl Theme {
             result.insert(name, ThemeOrigin::Stock.into());
         }
 
-        for name in Self::custom_names(app_dirs)? {
-            result.insert(name?, ThemeOrigin::Custom.into());
+        if let Ok(names) = Self::custom_names(app_dirs) {
+            for name in names {
+                match name {
+                    Ok(name) => {
+                        result.insert(name, ThemeOrigin::Custom.into());
+                    }
+                    Err(e) => {
+                        eprintln!("failed to list custom theme: {}", e);
+                    }
+                }
+            }
         }
 
         Ok(result)


### PR DESCRIPTION
To select themes with preview [fzf](https://github.com/junegunn/fzf) tool can be used like this:
```bash
hl --list-themes | fzf --preview-window="top,80%" --preview="head -n 100 example.log | hl -c --theme {}"
```
