### PR TITLE
new: Nested objects flattening feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: cargo build --verbose --benches
       - name: Run tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate code coverage
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
             asset: hl-windows.zip
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.28.2-alpha.2"
+version = "0.29.0-alpha.1"
 
 [[package]]
 name = "enum-map"
@@ -757,7 +757,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.28.2-alpha.2"
+version = "0.29.0-alpha.1"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.28.2-alpha.2"
+version = "0.29.0-alpha.1"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Output Options:
       --no-raw                Disable raw source messages output, overrides --raw option
       --raw-fields            Output field values as is, without unescaping or prettifying
   -h, --hide <KEY>            Hide or reveal fields with the specified keys, prefix with ! to reveal, specify '!*' to reveal all
+      --flatten <WHEN>        Whether to flatten objects [env: HL_FLATTEN=] [default: always] [possible values: never, always]
   -t, --time-format <FORMAT>  Time format, see https://man7.org/linux/man-pages/man1/date.1.html [env: HL_TIME_FORMAT=] [default: "%b %d %T.%3N"]
   -Z, --time-zone <TZ>        Time zone name, see column "TZ identifier" at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones [env: HL_TIME_ZONE=] [default: UTC]
   -L, --local                 Use local time zone, overrides --time-zone option

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -52,6 +52,7 @@ fields:
 
 # Formatting settings.
 formatting:
+  flatten: always
   punctuation:
     logger-name-separator: ':'
     field-key-value-separator: '='

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,7 @@ use crate::{
     config,
     error::*,
     level::{LevelValueParser, RelaxedLevel},
+    settings,
 };
 
 // ---
@@ -152,6 +153,21 @@ pub struct Opt {
         help_heading = heading::OUTPUT
     )]
     pub hide: Vec<String>,
+
+    /// Whether to flatten objects.
+    #[arg(
+        long,
+        env = "HL_FLATTEN",
+        value_name = "WHEN",
+        value_enum,
+        default_value_t = config::get().formatting.flatten.as_ref().map(|x| match x{
+            settings::FlattenOption::Never => FlattenOption::Never,
+            settings::FlattenOption::Always => FlattenOption::Always,
+        }).unwrap_or(FlattenOption::Always),
+        overrides_with = "flatten",
+        help_heading = heading::OUTPUT
+    )]
+    pub flatten: FlattenOption,
 
     /// Time format, see https://man7.org/linux/man-pages/man1/date.1.html.
     #[arg(
@@ -358,6 +374,12 @@ pub enum UnixTimestampUnit {
     Ms,
     Us,
     Ns,
+}
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlattenOption {
+    Never,
+    Always,
 }
 
 mod heading {

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,7 @@ fn run() -> Result<()> {
             cli::UnixTimestampUnit::Us => Some(app::UnixTimestampUnit::Microseconds),
             cli::UnixTimestampUnit::Ns => Some(app::UnixTimestampUnit::Nanoseconds),
         },
+        flatten: opt.flatten != cli::FlattenOption::Never,
     });
 
     // Configure input.

--- a/src/model.rs
+++ b/src/model.rs
@@ -206,7 +206,7 @@ impl<'a> RawObject<'a> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn parse(&self) -> Result<Object<'a>> {
         match self {
             Self::Json(value) => json::from_str::<Object>(value.get()).map_err(Error::JsonParseError),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -57,7 +57,7 @@ impl Default for Settings {
 
 // ---
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Fields {
     pub predefined: PredefinedFields,
     pub ignore: Vec<String>,
@@ -86,7 +86,7 @@ pub struct TimeField(pub Field);
 impl Default for TimeField {
     fn default() -> Self {
         Self(Field {
-            names: vec!["time".into()],
+            names: vec!["time".into(), "ts".into()],
         })
     }
 }
@@ -104,7 +104,7 @@ impl Default for LevelField {
             variants: vec![LevelFieldVariant {
                 names: vec!["level".into()],
                 values: Level::iter()
-                    .map(|level| (level, vec![level.as_ref().into()]))
+                    .map(|level| (level, vec![level.as_ref().to_lowercase().into()]))
                     .collect(),
                 level: None,
             }],
@@ -200,6 +200,16 @@ pub struct Field {
 #[serde(rename_all = "kebab-case")]
 pub struct Formatting {
     pub punctuation: Punctuation,
+    pub flatten: Option<FlattenOption>,
+}
+
+// ---
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FlattenOption {
+    Never,
+    Always,
 }
 
 // ---
@@ -229,7 +239,7 @@ impl Default for Punctuation {
     fn default() -> Self {
         Self {
             logger_name_separator: ":".into(),
-            field_key_value_separator: ":".into(),
+            field_key_value_separator: "=".into(),
             string_opening_quote: "'".into(),
             string_closing_quote: "'".into(),
             source_location_separator: "@ ".into(),
@@ -253,7 +263,7 @@ impl Punctuation {
     pub fn test_default() -> Self {
         Self {
             logger_name_separator: ":".into(),
-            field_key_value_separator: ":".into(),
+            field_key_value_separator: "=".into(),
             string_opening_quote: "'".into(),
             string_closing_quote: "'".into(),
             source_location_separator: "@ ".into(),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -224,7 +224,7 @@ impl<'a, B: Push<u8>> Styler<'a, B> {
 }
 
 impl<'a, B: Push<u8>> StylingPush<B> for Styler<'a, B> {
-    #[inline(always)]
+    #[inline]
     fn element<R, F: FnOnce(&mut Self) -> R>(&mut self, element: Element, f: F) -> R {
         let style = self.current;
         self.set(element);
@@ -232,11 +232,13 @@ impl<'a, B: Push<u8>> StylingPush<B> for Styler<'a, B> {
         self.set_style(style);
         result
     }
-    #[inline(always)]
+
+    #[inline]
     fn space(&mut self) {
         self.buf.push(b' ');
     }
-    #[inline(always)]
+
+    #[inline]
     fn batch<F: FnOnce(&mut B)>(&mut self, f: F) {
         self.sync();
         f(self.buf)


### PR DESCRIPTION
### Added
* `--flatten` command line option.
* `HL_FLATTEN` environment variable
* `formatting.flatten` configuration file option.
```
--flatten <WHEN>        Whether to flatten objects [env: HL_FLATTEN=] [default: always] [possible values: never, always]
```
The default value is "always", which means that all nested objects are now flattened by default.

#### Before
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/pamburus/hl/assets/12778560/4d402d21-7d7e-4bfb-b424-41a2bcf90d9c" width="100%">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/pamburus/hl/assets/12778560/05d35425-3447-49fe-a886-916bf4becb08" width="100%">
  <img />
</picture>

#### After
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/pamburus/hl/assets/12778560/149cacc1-027c-40f1-b4a6-ad7411f96447" width="100%">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/pamburus/hl/assets/12778560/538ce39c-3e41-47af-a680-8456e7cb6a5f" width="100%">
  <img />
</picture>

### Reasoning
It is very difficult to read logs with nested objects because you have to collect a lot of scattered keys to construct a path and understand what the fully qualified key really is.

### Opt out
To preserve the old behavior, explicitly specify `--flatten never` or `HL_FLATTEN=never`, or set `formatting.flatten` to `never` in the configuration file.