### PR TITLE
new: Added configuration options to force showing time and level fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.29.0-alpha.12"
+version = "0.29.0-alpha.13"
 
 [[package]]
 name = "enum-map"
@@ -758,7 +758,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.29.0-alpha.12"
+version = "0.29.0-alpha.13"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.29.0-alpha.12"
+version = "0.29.0-alpha.13"
 edition = "2021"
 license = "MIT"
 

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -10,6 +10,7 @@ fields:
   # Configuration of the predefined set of fields.
   predefined:
     time:
+      show: auto
       names:
         [
           ts,
@@ -24,6 +25,7 @@ fields:
     logger:
       names: [logger, LOGGER, Logger]
     level:
+      show: auto
       variants:
         - names: [level, LEVEL, Level]
           values:

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,7 @@ use crate::{
     model::{Filter, Parser, ParserSettings, RawRecord, Record, RecordFilter, RecordWithSourceConstructor},
     query::Query,
     scanning::{BufFactory, Delimit, Delimiter, Scanner, SearchExt, Segment, SegmentBuf, SegmentBufFactory},
-    settings::{Fields, Formatting},
+    settings::{FieldShowOption, Fields, Formatting},
     theme::{Element, StylingPush, Theme},
     timezone::Tz,
     IncludeExcludeKeyFilter,
@@ -670,7 +670,9 @@ impl App {
                     self.options.formatting.clone(),
                 )
                 .with_field_unescaping(!self.options.raw_fields)
-                .with_flatten(self.options.flatten),
+                .with_flatten(self.options.flatten)
+                .with_always_show_time(self.options.fields.settings.predefined.time.show == FieldShowOption::Always)
+                .with_always_show_level(self.options.fields.settings.predefined.level.show == FieldShowOption::Always),
             )
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -289,6 +289,7 @@ impl Eq for RawArray<'_> {}
 
 // ---
 
+#[derive(Default)]
 pub struct Record<'a> {
     pub ts: Option<Timestamp<'a>>,
     pub message: Option<RawValue<'a>>,
@@ -335,6 +336,7 @@ impl<'a> Record<'a> {
     }
 }
 
+#[derive(Default)]
 pub struct RecordFields<'a> {
     pub(crate) head: heapless::Vec<(&'a str, RawValue<'a>), RECORD_EXTRA_CAPACITY>,
     pub(crate) tail: Vec<(&'a str, RawValue<'a>)>,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -94,9 +94,7 @@ pub struct TimeField(pub Field);
 
 impl Default for TimeField {
     fn default() -> Self {
-        Self(Field {
-            names: vec!["time".into(), "ts".into()],
-        })
+        Self(Field::new(vec!["time".into(), "ts".into()]))
     }
 }
 
@@ -104,12 +102,14 @@ impl Default for TimeField {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LevelField {
+    pub show: FieldShowOption,
     pub variants: Vec<LevelFieldVariant>,
 }
 
 impl Default for LevelField {
     fn default() -> Self {
         Self {
+            show: FieldShowOption::default(),
             variants: vec![LevelFieldVariant {
                 names: vec!["level".into()],
                 values: Level::iter()
@@ -138,9 +138,7 @@ pub struct MessageField(Field);
 
 impl Default for MessageField {
     fn default() -> Self {
-        Self(Field {
-            names: vec!["msg".into()],
-        })
+        Self(Field::new(vec!["msg".into()]))
     }
 }
 
@@ -151,9 +149,7 @@ pub struct LoggerField(Field);
 
 impl Default for LoggerField {
     fn default() -> Self {
-        Self(Field {
-            names: vec!["logger".into()],
-        })
+        Self(Field::new(vec!["logger".into()]))
     }
 }
 
@@ -164,9 +160,7 @@ pub struct CallerField(Field);
 
 impl Default for CallerField {
     fn default() -> Self {
-        Self(Field {
-            names: vec!["caller".into()],
-        })
+        Self(Field::new(vec!["caller".into()]))
     }
 }
 
@@ -177,9 +171,7 @@ pub struct CallerFileField(Field);
 
 impl Default for CallerFileField {
     fn default() -> Self {
-        Self(Field {
-            names: vec!["file".into()],
-        })
+        Self(Field::new(vec!["file".into()]))
     }
 }
 
@@ -190,9 +182,7 @@ pub struct CallerLineField(Field);
 
 impl Default for CallerLineField {
     fn default() -> Self {
-        Self(Field {
-            names: vec!["line".into()],
-        })
+        Self(Field::new(vec!["line".into()]))
     }
 }
 
@@ -201,6 +191,17 @@ impl Default for CallerLineField {
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Field {
     pub names: Vec<String>,
+    #[serde(default)]
+    pub show: FieldShowOption,
+}
+
+impl Field {
+    pub fn new(names: Vec<String>) -> Self {
+        Self {
+            names,
+            show: FieldShowOption::Auto,
+        }
+    }
 }
 
 // ---
@@ -219,6 +220,21 @@ pub struct Formatting {
 pub enum FlattenOption {
     Never,
     Always,
+}
+
+// ---
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum FieldShowOption {
+    Auto,
+    Always,
+}
+
+impl Default for FieldShowOption {
+    fn default() -> Self {
+        Self::Auto
+    }
 }
 
 // ---
@@ -326,7 +342,8 @@ mod tests {
         assert_eq!(
             settings.fields.predefined.time,
             TimeField(Field {
-                names: vec!["ts".into()]
+                names: vec!["ts".into()],
+                show: FieldShowOption::Auto,
             })
         );
         assert_eq!(settings.time_format, "%b %d %T.%3N");


### PR DESCRIPTION
Also changed the default behavior to show them only if present.

Config file changes:
```yaml
fields:
  predefined:
    time:
      show: auto
    level:
      show: auto
```

Valid values: `auto`, `always`.