### PR TITLE
fix: Fixed smart new line delimiter logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.29.1"
+version = "0.29.2-alpha.1"
 
 [[package]]
 name = "enum-map"
@@ -768,7 +768,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.29.1"
+version = "0.29.2-alpha.1"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.29.1"
+version = "0.29.2-alpha.1"
 edition = "2021"
 license = "MIT"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -837,6 +837,7 @@ impl<'a, Formatter: RecordWithSourceFormatter, Filter: RecordFilter> SegmentProc
     {
         for line in self.options.delimiter.clone().into_searcher().split(data) {
             if line.len() == 0 {
+                buf.push(b'\n');
                 continue;
             }
 
@@ -1163,6 +1164,18 @@ mod tests {
             std::str::from_utf8(&output).unwrap(),
             format!("{}\n{}\n", input1, input2),
         );
+    }
+
+    #[test]
+    fn test_smart_delim_combo() {
+        const L1: &str = r#"{}"#;
+        const L2: &str = r#"{}"#;
+
+        let input = input(format!("{}\n\r\n{}\n", L1, L2));
+        let mut output = Vec::new();
+        let app = App::new(options().with_raw(true));
+        app.run(vec![input], &mut output).unwrap();
+        assert_eq!(std::str::from_utf8(&output).unwrap(), format!("{}\n\n{}\n", L1, L2),);
     }
 
     fn input<S: Into<String>>(s: S) -> InputHolder {

--- a/src/scanning.rs
+++ b/src/scanning.rs
@@ -404,7 +404,7 @@ impl Search for SmartNewLineSearcher {
         let b = if edge { 0 } else { 1 };
 
         buf[b..].iter().position(|x| *x == b'\n').and_then(|i| {
-            if i > 0 && buf[i] == b'\r' {
+            if i > 0 && buf[i - 1] == b'\r' {
                 Some(b + i - 1..b + i + 1)
             } else {
                 Some(b + i..b + i + 1)
@@ -864,6 +864,21 @@ mod tests {
         let mut iter = searcher.split(buf);
 
         assert_eq!(iter.next(), Some(&b""[..]));
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn test_delim_combo_auto() {
+        let searcher = SmartNewLine.into_searcher();
+        let buf = b"a\n\r\nb\naaaa\n\r\nbbbb\n";
+        let mut iter = searcher.split(buf);
+
+        assert_eq!(iter.next(), Some(&b"a"[..]));
+        assert_eq!(iter.next(), Some(&b""[..]));
+        assert_eq!(iter.next(), Some(&b"b"[..]));
+        assert_eq!(iter.next(), Some(&b"aaaa"[..]));
+        assert_eq!(iter.next(), Some(&b""[..]));
+        assert_eq!(iter.next(), Some(&b"bbbb"[..]));
         assert_eq!(iter.next(), None);
     }
 


### PR DESCRIPTION
The CR-LF sequence was not parsed correctly.
Additionally, empty lines were incorrectly skipped in the output, fixed that also.