### PR TITLE
fix: Fixed sorting when some lines are empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.29.2-alpha.3"
+version = "0.29.2-alpha.4"
 
 [[package]]
 name = "enum-map"
@@ -768,7 +768,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.29.2-alpha.3"
+version = "0.29.2-alpha.4"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.29.2-alpha.3"
+version = "0.29.2-alpha.4"
 edition = "2021"
 license = "MIT"
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -442,6 +442,8 @@ impl Indexer {
                         }
                     }
                 }
+            } else {
+                stat.add_invalid();
             }
             lines.push((ts.or(prev_ts), i as u32, offset));
             offset += data_len as u32 + 1;


### PR DESCRIPTION
If some lines in the input data were empty, some other lines could be lost in the output.