### PR TITLE
new: Automatically quote ambiguous string values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encstr"
-version = "0.29.4-alpha.1"
+version = "0.29.4-alpha.2"
 
 [[package]]
 name = "enum-map"
@@ -768,7 +768,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.29.4-alpha.1"
+version = "0.29.4-alpha.2"
 dependencies = [
  "atoi",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.29.4-alpha.1"
+version = "0.29.4-alpha.2"
 edition = "2021"
 license = "MIT"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -922,6 +922,7 @@ pub trait RecordObserver {
 pub struct RecordIgnorer {}
 
 impl RecordObserver for RecordIgnorer {
+    #[inline]
     fn observe_record<'a>(&mut self, _: &'a Record<'a>, _: Range<usize>) {}
 }
 
@@ -932,6 +933,7 @@ struct TimestampIndexBuilder {
 }
 
 impl RecordObserver for TimestampIndexBuilder {
+    #[inline]
     fn observe_record<'a>(&mut self, record: &'a Record<'a>, location: Range<usize>) {
         if let Some(ts) = record.ts.as_ref().and_then(|ts| ts.unix_utc()).map(|ts| ts.into()) {
             self.result.lines.push(TimestampIndexLine { location, ts });
@@ -942,6 +944,7 @@ impl RecordObserver for TimestampIndexBuilder {
 // ---
 
 impl<T: FnMut(&Record, Range<usize>)> RecordObserver for T {
+    #[inline]
     fn observe_record<'b>(&mut self, record: &'b Record<'b>, location: Range<usize>) {
         self(record, location)
     }


### PR DESCRIPTION
String values that look like "false", "true", "null" or like a number will be now quoted automatically to be distinguished from corresponding non-string values.