### PR TITLE
new: Added new dark and light true-color themes `tc24d-b2` and `tc24l-b2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.29.5-alpha.3"
+version = "0.29.5-alpha.4"
 dependencies = [
  "bincode",
  "bitmask",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.29.5-alpha.3"
+version = "0.29.5-alpha.4"
 edition = "2021"
 license = "MIT"
 

--- a/etc/defaults/themes/tc24d-b2.yaml
+++ b/etc/defaults/themes/tc24d-b2.yaml
@@ -1,0 +1,62 @@
+palette:
+  - &default '#abb2bf'
+  - &strong '#cfd7e5'
+  - &red '#e06c75'
+  - &gray '#636d83'
+  - &blue '#61afef'
+  - &yellow '#f4a460'
+  - &cyan '#56b6c2'
+  - &magenta '#c678dd'
+  - &green '#98c379'
+
+elements:
+  input:
+    foreground: *gray
+  time:
+    foreground: *gray
+  logger:
+    foreground: *gray
+  caller:
+    foreground: *gray
+    modes: [italic]
+  level:
+    foreground: *gray
+  message:
+    foreground: *strong
+  field:
+    foreground: *gray
+  key:
+    foreground: *blue
+  ellipsis:
+    foreground: *gray
+  object:
+    foreground: *strong
+    modes: [bold]
+  array:
+    foreground: *strong
+    modes: [bold]
+  string:
+    foreground: *default
+  number:
+    foreground: *green
+  boolean:
+    foreground: *yellow
+  'null':
+    foreground: *red
+levels:
+  debug:
+    level-inner:
+      foreground: *magenta
+  info:
+    level-inner:
+      foreground: *cyan
+  warning:
+    level-inner:
+      foreground: *yellow
+    message:
+      foreground: *yellow
+  error:
+    level-inner:
+      foreground: *red
+    message:
+      foreground: *red

--- a/etc/defaults/themes/tc24l-b2.yaml
+++ b/etc/defaults/themes/tc24l-b2.yaml
@@ -1,0 +1,62 @@
+palette:
+  - &default '#5d677b'
+  - &strong '#000000'
+  - &red '#dc143c'
+  - &gray '#778899'
+  - &blue '#4169e1'
+  - &yellow '#ff8c00'
+  - &cyan '#00ced1'
+  - &magenta '#ba55d3'
+  - &green '#228b22'
+
+elements:
+  input:
+    foreground: *gray
+  time:
+    foreground: *gray
+  logger:
+    foreground: *gray
+  caller:
+    foreground: *gray
+    modes: [italic]
+  level:
+    foreground: *gray
+  message:
+    foreground: *strong
+  field:
+    foreground: *gray
+  key:
+    foreground: *blue
+  ellipsis:
+    foreground: *gray
+  object:
+    foreground: *strong
+    modes: [bold]
+  array:
+    foreground: *strong
+    modes: [bold]
+  string:
+    foreground: *default
+  number:
+    foreground: *green
+  boolean:
+    foreground: *yellow
+  'null':
+    foreground: *red
+levels:
+  debug:
+    level-inner:
+      foreground: *magenta
+  info:
+    level-inner:
+      foreground: *cyan
+  warning:
+    level-inner:
+      foreground: *yellow
+    message:
+      foreground: *yellow
+  error:
+    level-inner:
+      foreground: *red
+    message:
+      foreground: *red


### PR DESCRIPTION
Added modified versions of tc24d-blue and tc24l-blue themes without bold and reverse attributes on message and levels.