### PR TITLE
new: Automatically add different spellings of level values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.29.6"
+version = "0.29.7-alpha.1"
 dependencies = [
  "bincode",
  "bitmask",
@@ -822,6 +822,7 @@ dependencies = [
  "stats_alloc",
  "strum",
  "thiserror",
+ "titlecase",
  "wildflower",
  "wildmatch",
  "winapi-util",
@@ -1702,6 +1703,16 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "titlecase"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc5e312c2e5385c8d3d31487041ca8ceaec09a8a1174bdfa9c6418c5f6b36fa"
+dependencies = [
+ "regex",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.29.6"
+version = "0.29.7-alpha.1"
 edition = "2021"
 license = "MIT"
 
@@ -44,7 +44,7 @@ clap_complete = "4"
 clap_mangen = "0"
 closure = "0"
 collection_macros = "0"
-config = "0"
+config = { version = "0", features = ["yaml", "json", "toml"] }
 crossbeam-channel = "0"
 crossbeam-queue = "0"
 crossbeam-utils = "0"
@@ -77,6 +77,7 @@ signal-hook = "0"
 snap = "1"
 strum = { version = "0", features = ["derive"] }
 thiserror = "1"
+titlecase = "3"
 wildflower = { git = "https://github.com/cassaundra/wildflower.git" }
 winapi-util = { version = "0" }
 wyhash = "0"

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -32,10 +32,10 @@ fields:
       variants:
         - names: [level, LEVEL, Level]
           values:
-            debug: [debug, Debug]
-            info: [info, information, Information]
-            warning: [warning, Warning, warn]
-            error: [error, Error, err, fatal, critical, panic]
+            debug: [debug]
+            info: [info, information]
+            warning: [warning, warn]
+            error: [error, err, fatal, critical, panic]
         - names: [PRIORITY]
           values:
             debug: [7]

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,10 @@ pub mod global {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::Settings;
+
+    use maplit::hashmap;
+
+    use crate::{level::Level, settings::Settings};
 
     #[test]
     fn test_default() {
@@ -88,6 +91,24 @@ mod tests {
         assert_eq!(settings.fields.predefined.time.0.names, &["ts"]);
         assert_eq!(settings.fields.predefined.message.0.names, &["msg"]);
         assert_eq!(settings.fields.predefined.level.variants.len(), 2);
+    }
+
+    #[test]
+    fn test_issue_288() {
+        let settings = super::load(Some("src/testing/assets/configs/issue-288.yaml")).unwrap();
+        assert_eq!(settings.fields.predefined.level.variants.len(), 1);
+        let variant = &settings.fields.predefined.level.variants[0];
+        assert_eq!(variant.names, vec!["level".to_owned()]);
+        assert_eq!(
+            variant.values,
+            hashmap! {
+                Level::Debug => vec!["dbg".to_owned()],
+                // TODO: replace `"inf"` with `"INF"` when https://github.com/mehcode/config-rs/issues/568 is fixed
+                Level::Info => vec!["inf".to_owned()],
+                Level::Warning => vec!["wrn".to_owned()],
+                Level::Error => vec!["ERR".to_owned()],
+            }
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,6 +14,7 @@ use chrono::{DateTime, Utc};
 use regex::Regex;
 use serde::de::{Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::{self as json};
+use titlecase::titlecase;
 use wildflower::Pattern;
 
 // other local crates
@@ -525,6 +526,9 @@ impl ParserSettings {
             for (level, values) in &variant.values {
                 for value in values {
                     mapping.insert(value.clone(), level.clone());
+                    mapping.insert(value.to_lowercase(), level.clone());
+                    mapping.insert(value.to_uppercase(), level.clone());
+                    mapping.insert(titlecase(value), level.clone());
                 }
             }
             let k = self.level.len();

--- a/src/testing/assets/configs/issue-288.yaml
+++ b/src/testing/assets/configs/issue-288.yaml
@@ -1,0 +1,11 @@
+fields:
+  predefined:
+    level:
+      show: auto
+      variants:
+        - names: [level]
+          values:
+            debug: [dbg]
+            info: [INF]
+            warning: [wrn]
+            error: [ERR]


### PR DESCRIPTION
Now in addition to the original spelling found in the configuration file, level values are automatically registered in lower case, upper case and title case.

Closes #288 