### PR TITLE
Use deko::AnyDecoder instead of flate2::GzDecoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "307e3004becf10f5a6e0d59d20f3cd28231b0e0827a96cd3e0ce6d14bc1e4bb3"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "capnp"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +265,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -597,6 +620,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "deko"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223a82f31424d7cce5343e2aa74aa73df39a39618b16b8debb67e80528d5302f"
+dependencies = [
+ "bzip2",
+ "flate2",
+ "xz",
+ "zstd",
+]
+
+[[package]]
 name = "derive_deref"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +928,7 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
+ "deko",
  "derive_deref",
  "dirs",
  "dirs-sys",
@@ -1063,6 +1099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1191,17 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "maplit"
@@ -1378,6 +1434,12 @@ checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plotters"
@@ -2228,6 +2290,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
+dependencies = [
+ "xz2",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,4 +2381,32 @@ dependencies = [
  "quote",
  "syn 2.0.87",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ config = { version = "0", features = ["yaml", "json", "toml"] }
 crossbeam-channel = "0"
 crossbeam-queue = "0"
 crossbeam-utils = "0"
+deko = "0"
 derive_deref = "1"
 dirs = "5"
 dirs-sys = "0"

--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ See other [screenshots](https://github.com/pamburus/hl-extra/tree/90be58af2fb91d
 
     Concatenates and displays all `*.log` files found in the current directory.
 
-### Support for gzipped log files
+### Support for compressed (bzip2, gzip, xz, zstd) log files
 
-* Concatenate all log files including gzipped log files
+* Concatenate all log files including compressed log files
 
     Command
 
     ```sh
-    hl $(ls -tr /var/log/example/*.{log,log.gz})
+    hl $(ls -tr /var/log/example/*.{log,log.gz,log.zst,s})
     ```
 
-    Concatenates and displays all `*.log` and `*.log.gz` files found in `/var/log/example/`.
+    Concatenates and displays all `*.log`, `*.log.gz`, `*.log.zst` and `*.s` (will detect compression) files found in `/var/log/example/`.
 
 ### Automatic usage of pager
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -566,6 +566,24 @@ mod tests {
         assert_eq!(err.to_string().contains(filename), true);
     }
 
+    #[test]
+    fn test_input_gzip() {
+        use std::io::Cursor;
+        let data = Cursor::new(
+            // echo '' | gzip -cf | od -A n -t u1 -w40| sed -e 's/^  *//; s/  */, /g'
+            vec![31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 227, 2, 0, 147, 6, 215, 50, 1, 0, 0, 0],
+        );
+        let mut input = Input::open_stream(&PathBuf::from("test.log.gz"), Box::new(data)).unwrap();
+        let mut buf = [0; 32];
+        let result = input.stream.read(&mut buf);
+        assert!(result.is_ok());
+        let got = result.unwrap();
+        if got != 1 {
+            println!("got {}, wanted 1", got);
+        }
+        assert!(got == 1);
+    }
+
     struct FailingReader;
 
     impl Read for FailingReader {

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 // third-party imports
-use flate2::bufread::GzDecoder;
+use deko::bufread::AnyDecoder;
 use nu_ansi_term::Color;
 
 // local imports
@@ -184,10 +184,7 @@ impl Input {
     }
 
     pub fn open_stream(path: &PathBuf, stream: Box<dyn ReadSeek + Send + Sync>) -> io::Result<Self> {
-        let stream: InputStream = match path.extension().map(|x| x.to_str()) {
-            Some(Some("gz")) => Box::new(GzDecoder::new(BufReader::new(stream))),
-            _ => Box::new(stream),
-        };
+        let stream: InputStream = Box::new(AnyDecoder::new(BufReader::new(stream)));
         Ok(Self::new(InputReference::File(path.clone()), stream))
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -570,18 +570,15 @@ mod tests {
     fn test_input_gzip() {
         use std::io::Cursor;
         let data = Cursor::new(
-            // echo '' | gzip -cf | od -A n -t u1 -w40| sed -e 's/^  *//; s/  */, /g'
-            vec![31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 227, 2, 0, 147, 6, 215, 50, 1, 0, 0, 0],
+            // echo 'test' | gzip -cf | xxd -p | sed 's/\(..\)/\\x\1/g'
+            b"\x1f\x8b\x08\x00\x9e\xdd\x48\x67\x00\x03\x2b\x49\x2d\x2e\xe1\x02\x00\xc6\x35\xb9\x3b\x05\x00\x00\x00",
         );
         let mut input = Input::open_stream(&PathBuf::from("test.log.gz"), Box::new(data)).unwrap();
-        let mut buf = [0; 32];
-        let result = input.stream.read(&mut buf);
+        let mut buf = Vec::new();
+        let result = input.stream.read_to_end(&mut buf);
         assert!(result.is_ok());
-        let got = result.unwrap();
-        if got != 1 {
-            println!("got {}, wanted 1", got);
-        }
-        assert!(got == 1);
+        assert_eq!(result.unwrap(), 5);
+        assert_eq!(buf, b"test\n");
     }
 
     struct FailingReader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,10 @@ use hl::{
 
 // supported compression formats
 const COMPRESSION_FORMATS: phf::Map<&str, &str> = phf_map! {
+    "bz2" => "bzip2",
     "gz" => "gzip",
+    "xz" => "xz",
+    "zst" => "zstd"
 };
 
 // ---


### PR DESCRIPTION
To decode compressed files/streams automatically, not just based on extension.

A gzip usually has .gz as extension, but not always (I have .s, for example).
This could be configurable, but I think checking the magic two \x1f\x8b starting bytes would be more adequate.

The simplest thing would be reading the first two bytes of the stream, check it and decide whether to GzDecode it or not.
But I don't know Rust, so that's hard - it's easier to use a ready-made crate, like deko (or autocompress).
