### PR TITLE
fix: workaround for fs::canonicalize failures on fifo files on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [master, release/*]
+    branches: [master, release/**]
   pull_request:
-    branches: [master, release/*]
+    branches: [master, release/**]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.debug
 /.vscode
 /*.log
 /*.log.bz2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.30.2-alpha.4"
+version = "0.30.2-alpha.5"
 dependencies = [
  "bincode",
  "byte-strings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr", "crate/heapopt"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.30.2-alpha.4"
+version = "0.30.2-alpha.5"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Closes #656 