### PR TITLE
fix: workaround for fs::canonicalize failures on fifo files on linux (#657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [master, release/*]
+    branches: [master, release/**]
   pull_request:
-    branches: [master, release/*]
+    branches: [master, release/**]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.31.0-alpha.1"
+version = "0.31.0-alpha.2"
 dependencies = [
  "bincode",
  "byte-strings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr", "crate/heapopt"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.31.0-alpha.1"
+version = "0.31.0-alpha.2"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Merges release/0.30.2 into master
Closes #656 