### PR TITLE
feat: updated installation instructions for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ High performance and convenient features are the main goals.
 
 ## Installation options
 
-* Install using [homebrew](https://brew.sh) on macOS or Linux
+* Install using [homebrew](https://brew.sh) on macOS
 
     ```sh
-    brew install pamburus/tap/hl
+    brew install hl
     ```
 
 * Download and extract using `curl` and `tar` on macOS

--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ High performance and convenient features are the main goals.
     curl -sSfL https://github.com/pamburus/hl/releases/latest/download/hl-macos.tar.gz | tar xz
     ```
 
-* Download and extract using `curl` and `tar` on Linux
+* Download and extract using `curl` and `tar` on Linux (x86_64)
 
     ```sh
     curl -sSfL https://github.com/pamburus/hl/releases/latest/download/hl-linux-x86_64-musl.tar.gz | tar xz
+    ```
+
+* Download and extract using `curl` and `tar` on Linux (arm64/aarch64)
+
+    ```sh
+    curl -sSfL https://github.com/pamburus/hl/releases/latest/download/hl-linux-arm64-musl.tar.gz | tar xz
     ```
 
 * Install [AUR package](https://aur.archlinux.org/packages/hl-log-viewer-bin) on Arch Linux


### PR DESCRIPTION
Thanks to @chenrui333 [hl](https://github.com/pamburus/hl) is now available in [homebrew-core](https://github.com/Homebrew/homebrew-core) ([#208082](https://github.com/Homebrew/homebrew-core/pull/208082)) and can be installed with the command
```sh
brew install sh
```

This pull request updates the installation instructions in the README.md accordingly.