### PR TITLE
fix: fixed warning color in `hl-dark` theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.31.0-alpha.13"
+version = "0.31.0-alpha.14"
 dependencies = [
  "base32",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [".", "crate/encstr", "crate/heapopt"]
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.31.0-alpha.13"
+version = "0.31.0-alpha.14"
 edition = "2021"
 license = "MIT"
 

--- a/etc/defaults/themes/hl-dark.yaml
+++ b/etc/defaults/themes/hl-dark.yaml
@@ -47,9 +47,9 @@ levels:
       foreground: 146
   warning:
     level-inner:
-      foreground: 228
+      foreground: 215
     message:
-      foreground: 228
+      foreground: 215
   error:
     level-inner:
       foreground: 210


### PR DESCRIPTION
### Changed 
![screenshot-hl-dark](https://raw.githubusercontent.com/pamburus/hl-extra/bdc78073a46e62568c8fc4d9dbc0e908345d581c/screenshot/hl-dark/dark.svg)
### To
![screenshot-hl-dark](https://raw.githubusercontent.com/pamburus/hl-extra/c461caa348f3a118547a8b74c943dc0135282378/screenshot/hl-dark/dark.svg)