### PR TITLE
feat: added theme tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.31.0-alpha.22"
+version = "0.31.0-alpha.23"
 dependencies = [
  "base32",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.31.0-alpha.22"
+version = "0.31.0-alpha.23"
 edition = "2024"
 license = "MIT"
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ include build/make/common.mk
 SHELL = /bin/bash
 
 # Local variables
-THEMES = $(notdir $(basename $(wildcard etc/defaults/themes/*.yaml)))
 SCREENSHOT_SAMPLE = cafe.log
 
 # Exported variables
@@ -13,13 +12,6 @@ export RUST_BACKTRACE=1
 
 # The list of files that are intentionally ignored while being tracked
 ignored-tracked-files = .vscode/settings.json
-
-# Theme mappings
-theme-ayu-dark-24 = ayu
-theme-ayu-light-24 = ayu-light
-theme-ayu-mirage-24 = $(if $(filter dark,$1),ayu-mirage,)
-theme-one-dark-24 = one-half-dark
-theme-one-light-24 = one-half-light
 
 ## Build debug target
 .PHONY: build
@@ -95,12 +87,9 @@ clean: contrib-build
 
 ## Create screenshots
 .PHONY: screenshots
-screenshots: build $(THEMES:%=screenshot-%)
-
-screenshot-%: build contrib-screenshots
-	@$(SHELL) contrib/bin/screenshot.sh light $(SCREENSHOT_SAMPLE) $* "$(call theme-$*,light)"
-	@$(SHELL) contrib/bin/screenshot.sh dark $(SCREENSHOT_SAMPLE) $* "$(call theme-$*,dark)"
-.PHONY: screenshot-%
+screenshots: build
+	@$(SHELL) contrib/bin/screenshot.sh light $(SCREENSHOT_SAMPLE)
+	@$(SHELL) contrib/bin/screenshot.sh dark $(SCREENSHOT_SAMPLE)
 
 ## Collect coverage
 .PHONY: coverage

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ Advanced Options:
   -C, --concurrency <N>             Number of processing threads [env: HL_CONCURRENCY=]
       --shell-completions <SHELL>   Print shell auto-completion script and exit [possible values: bash, elvish, fish, powershell, zsh]
       --man-page                    Print man page and exit
-      --list-themes                 Print available themes and exit
+      --list-themes[=<TAGS>]        Print available themes optionally filtered by tags [dark, light, 16color, 256color, truecolor]
       --dump-index                  Print debug index metadata (in --sort mode) and exit
 ```
 

--- a/benches/bench/ws/hl/theme.rs
+++ b/benches/bench/ws/hl/theme.rs
@@ -87,6 +87,7 @@ pub(super) fn bench(c: &mut Criterion) {
 
 fn theme() -> Theme {
     Theme::from(&themecfg::Theme {
+        tags: Default::default(),
         elements: hashmap! {
             Element::Time => Style {
                 modes: Vec::default(),

--- a/build/ci/coverage.sh
+++ b/build/ci/coverage.sh
@@ -48,6 +48,7 @@ function test() {
     ${MAIN_EXECUTABLE:?} --config - --shell-completions bash > /dev/null
     ${MAIN_EXECUTABLE:?} --config - --man-page > /dev/null
     ${MAIN_EXECUTABLE:?} --config - --list-themes > /dev/null
+    ${MAIN_EXECUTABLE:?} --config - --list-themes=dark,16color > /dev/null
     ${MAIN_EXECUTABLE:?} --config - sample/prometheus.log -P > /dev/null
     HL_DEBUG_LOG=info ${MAIN_EXECUTABLE:?} --config - sample/prometheus.log -P > /dev/null
     echo "" | ${MAIN_EXECUTABLE:?} --config - --concurrency 4 > /dev/null

--- a/contrib/bin/screenshot.sh
+++ b/contrib/bin/screenshot.sh
@@ -5,34 +5,81 @@ set -e
 HL_SRC=$(cd $(dirname ${0:?})/../.. && pwd)
 MODE=${1:?}
 SAMPLE=${2:?}
-THEME=${3:?}
-TERMFRAME_THEME=${4:-one-double}
+THEME=${3:-all}
+TERMFRAME_THEME=${4:-auto}
 TITLE="hl sample/${SAMPLE:?}"
 
-mkdir -p "${HL_SRC:?}"/extra/screenshot/${THEME:?}
+DEFAULT_TERMFRAME_THEME=one-double
 
-printf "generating screenshot for \e[1m%s\e[m sample and \e[1m%s\e[m mode with \e[1m%s\e[m theme" "${SAMPLE:?}" "${MODE:?}" "${THEME:?}"
-if [ "${TERMFRAME_THEME}" != "one-double" ]; then
-    printf " and \e[1m%s\e[m termframe theme" "${TERMFRAME_THEME:?}"
+function screenshot() {
+    local THEME=${1:?}
+    local TERMFRAME_THEME=${TERMFRAME_THEME:?}
+
+    # Theme mappings
+    if [ "${TERMFRAME_THEME}" == "auto" ]; then
+        case "${THEME}" in
+            ayu-dark-24)
+                TERMFRAME_THEME=ayu
+                ;;
+            ayu-light-24)
+                TERMFRAME_THEME=ayu-light
+                ;;
+            ayu-mirage-24)
+                TERMFRAME_THEME=ayu-mirage
+                ;;
+            one-dark-24)
+                TERMFRAME_THEME=one-half-dark
+                ;;
+            one-light-24)
+                TERMFRAME_THEME=one-half-light
+                ;;
+            *)
+                TERMFRAME_THEME="${DEFAULT_TERMFRAME_THEME:?}"
+                ;;
+        esac
+    fi
+
+    mkdir -p "${HL_SRC:?}"/extra/screenshot/${THEME:?}
+
+    printf "generating screenshot for \e[1m%s\e[m sample and \e[1m%s\e[m mode with \e[1m%s\e[m theme" "${SAMPLE:?}" "${MODE:?}" "${THEME:?}"
+    if [ "${TERMFRAME_THEME}" != "one-double" ]; then
+        printf " and \e[1m%s\e[m termframe theme" "${TERMFRAME_THEME:?}"
+    fi
+    printf "\n"
+
+    "${HL_SRC:?}"/contrib/bin/termframe.sh \
+        --title "${TITLE:?}" \
+        --mode ${MODE:?} \
+        -W 120 \
+        -H 23 \
+        --theme ${TERMFRAME_THEME:?} \
+        --font-family "JetBrains Mono, Fira Code, Cascadia Code, Source Code Pro, Consolas, Menlo, Monaco, DejaVu Sans Mono, monospace" \
+        --faint-font-weight 200 \
+        --faint-opacity 0.6 \
+        --font-size 12 \
+        --embed-fonts true \
+        -o "${HL_SRC:?}"/extra/screenshot/${THEME:?}/${MODE:?}.svg \
+        -- \
+        "${HL_SRC:?}"/target/debug/hl \
+            --config - \
+            --theme ${THEME:?} \
+            --time-format '%T' \
+            -P \
+            "${HL_SRC:?}"/sample/${SAMPLE:?}
+}
+
+function screenshot_all() {
+    get_themes | xargs -n1 | while read THEME; do
+        screenshot ${THEME:?}
+    done
+}
+
+function get_themes() {
+    "${HL_SRC:?}"/target/debug/hl --list-themes=${MODE:?}
+}
+
+if [ "${THEME:?}" == "all" ]; then
+    screenshot_all ${MODE:?} ${SAMPLE:?}
+else
+    screenshot ${THEME:?} ${TERMFRAME_THEME:?}
 fi
-printf "\n"
-
-"${HL_SRC:?}"/contrib/bin/termframe.sh \
-    --title "${TITLE:?}" \
-    --mode ${MODE:?} \
-    -W 120 \
-    -H 23 \
-    --theme ${TERMFRAME_THEME:?} \
-    --font-family "JetBrains Mono, Fira Code, Cascadia Code, Source Code Pro, Consolas, Menlo, Monaco, DejaVu Sans Mono, monospace" \
-    --faint-font-weight 200 \
-    --faint-opacity 0.6 \
-    --font-size 12 \
-    --embed-fonts true \
-    -o "${HL_SRC:?}"/extra/screenshot/${THEME:?}/${MODE:?}.svg \
-    -- \
-    "${HL_SRC:?}"/target/debug/hl \
-        --config - \
-        --theme ${THEME:?} \
-        --time-format '%T' \
-        -P \
-        "${HL_SRC:?}"/sample/${SAMPLE:?}

--- a/etc/defaults/themes/ayu-dark-24.yaml
+++ b/etc/defaults/themes/ayu-dark-24.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, truecolor]
+
 elements:
   input:
     foreground: "#565b66"

--- a/etc/defaults/themes/ayu-light-24.yaml
+++ b/etc/defaults/themes/ayu-light-24.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [light, truecolor]
+
 elements:
   input:
     foreground: "#a7aaad"

--- a/etc/defaults/themes/ayu-mirage-24.yaml
+++ b/etc/defaults/themes/ayu-mirage-24.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, truecolor]
+
 elements:
   input:
     foreground: "#707a8c"

--- a/etc/defaults/themes/classic-light.yaml
+++ b/etc/defaults/themes/classic-light.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [light, 16color]
+
 elements:
   input:
     foreground: bright-black
@@ -30,7 +32,7 @@ elements:
     foreground: cyan
   boolean:
     foreground: yellow
-  'null':
+  "null":
     foreground: yellow
 levels:
   trace:

--- a/etc/defaults/themes/classic-plus.yaml
+++ b/etc/defaults/themes/classic-plus.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, 16color]
+
 elements:
   input:
     foreground: bright-black
@@ -32,7 +34,7 @@ elements:
     foreground: blue
   boolean:
     foreground: red
-  'null':
+  "null":
     foreground: red
 levels:
   trace:

--- a/etc/defaults/themes/classic.yaml
+++ b/etc/defaults/themes/classic.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark]
+
 elements:
   input:
     foreground: bright-black
@@ -30,7 +32,7 @@ elements:
     foreground: cyan
   boolean:
     foreground: yellow
-  'null':
+  "null":
     foreground: yellow
 levels:
   trace:

--- a/etc/defaults/themes/dmt.yaml
+++ b/etc/defaults/themes/dmt.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, 256color]
+
 elements:
   input:
     foreground: bright-black
@@ -32,7 +34,7 @@ elements:
     foreground: 41
   boolean:
     foreground: 192
-  'null':
+  "null":
     foreground: 136
 levels:
   trace:

--- a/etc/defaults/themes/hl-dark.yaml
+++ b/etc/defaults/themes/hl-dark.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, 256color]
+
 elements:
   input:
     foreground: 30

--- a/etc/defaults/themes/hl-light.yaml
+++ b/etc/defaults/themes/hl-light.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [light, 256color]
+
 elements:
   input:
     foreground: 30

--- a/etc/defaults/themes/lsd.yaml
+++ b/etc/defaults/themes/lsd.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, 16color]
+
 elements:
   input:
     foreground: bright-black
@@ -32,7 +34,7 @@ elements:
     foreground: yellow
   boolean:
     foreground: yellow
-  'null':
+  "null":
     foreground: yellow
 levels:
   trace:

--- a/etc/defaults/themes/neutral.yaml
+++ b/etc/defaults/themes/neutral.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, light, 16color]
+
 elements:
   input:
     modes: [faint]

--- a/etc/defaults/themes/one-dark-24.yaml
+++ b/etc/defaults/themes/one-dark-24.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, truecolor]
+
 elements:
   input:
     foreground: "#426d77"

--- a/etc/defaults/themes/one-light-24.yaml
+++ b/etc/defaults/themes/one-light-24.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [light, truecolor]
+
 elements:
   input:
     foreground: "#a0a1a7"

--- a/etc/defaults/themes/tc24d-b2.yaml
+++ b/etc/defaults/themes/tc24d-b2.yaml
@@ -1,16 +1,18 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, truecolor]
+
 $palette:
-  - &default '#abb2bf'
-  - &strong '#cfd7e5'
-  - &red '#e06c75'
-  - &gray '#636d83'
-  - &blue '#61afef'
-  - &yellow '#f4a460'
-  - &cyan '#56b6c2'
-  - &magenta '#c678dd'
-  - &green '#98c379'
+  - &default "#abb2bf"
+  - &strong "#cfd7e5"
+  - &red "#e06c75"
+  - &gray "#636d83"
+  - &blue "#61afef"
+  - &yellow "#f4a460"
+  - &cyan "#56b6c2"
+  - &magenta "#c678dd"
+  - &green "#98c379"
 
 elements:
   input:
@@ -44,7 +46,7 @@ elements:
     foreground: *green
   boolean:
     foreground: *yellow
-  'null':
+  "null":
     foreground: *red
 levels:
   trace:
@@ -69,9 +71,9 @@ levels:
 indicators:
   sync:
     synced:
-      text: ' '
+      text: " "
     failed:
-      text: '!'
+      text: "!"
       inner:
         style:
           foreground: *yellow

--- a/etc/defaults/themes/tc24d-blue.yaml
+++ b/etc/defaults/themes/tc24d-blue.yaml
@@ -1,16 +1,18 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, truecolor]
+
 $palette:
-  - &default '#abb2bf'
-  - &strong '#cfd7e5'
-  - &red '#e06c75'
-  - &gray '#636d83'
-  - &blue '#61afef'
-  - &yellow '#d19a66'
-  - &cyan '#56b6c2'
-  - &magenta '#c678dd'
-  - &green '#98c379'
+  - &default "#abb2bf"
+  - &strong "#cfd7e5"
+  - &red "#e06c75"
+  - &gray "#636d83"
+  - &blue "#61afef"
+  - &yellow "#d19a66"
+  - &cyan "#56b6c2"
+  - &magenta "#c678dd"
+  - &green "#98c379"
 
 elements:
   input:
@@ -45,7 +47,7 @@ elements:
     foreground: *green
   boolean:
     foreground: *yellow
-  'null':
+  "null":
     foreground: *red
 levels:
   trace:
@@ -70,9 +72,9 @@ levels:
 indicators:
   sync:
     synced:
-      text: ' '
+      text: " "
     failed:
-      text: '!'
+      text: "!"
       inner:
         style:
           foreground: *yellow

--- a/etc/defaults/themes/tc24l-b2.yaml
+++ b/etc/defaults/themes/tc24l-b2.yaml
@@ -1,16 +1,18 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [light, truecolor]
+
 $palette:
-  - &default '#5d677b'
-  - &strong '#000000'
-  - &red '#dc143c'
-  - &gray '#778899'
-  - &blue '#4169e1'
-  - &yellow '#ff8c00'
-  - &cyan '#00ced1'
-  - &magenta '#ba55d3'
-  - &green '#228b22'
+  - &default "#5d677b"
+  - &strong "#000000"
+  - &red "#dc143c"
+  - &gray "#778899"
+  - &blue "#4169e1"
+  - &yellow "#ff8c00"
+  - &cyan "#00ced1"
+  - &magenta "#ba55d3"
+  - &green "#228b22"
 
 elements:
   input:
@@ -44,7 +46,7 @@ elements:
     foreground: *green
   boolean:
     foreground: *yellow
-  'null':
+  "null":
     foreground: *red
 levels:
   trace:
@@ -69,9 +71,9 @@ levels:
 indicators:
   sync:
     synced:
-      text: ' '
+      text: " "
     failed:
-      text: '!'
+      text: "!"
       inner:
         style:
           foreground: *yellow

--- a/etc/defaults/themes/tc24l-blue.yaml
+++ b/etc/defaults/themes/tc24l-blue.yaml
@@ -1,16 +1,18 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [light, truecolor]
+
 $palette:
-  - &default '#313641'
-  - &strong '#262a33'
-  - &red '#e06c75'
-  - &gray '#778899'
-  - &blue '#4169e1'
-  - &yellow '#ff8c00'
-  - &cyan '#48d1cc'
-  - &magenta '#da70d6'
-  - &green '#228b22'
+  - &default "#313641"
+  - &strong "#262a33"
+  - &red "#e06c75"
+  - &gray "#778899"
+  - &blue "#4169e1"
+  - &yellow "#ff8c00"
+  - &cyan "#48d1cc"
+  - &magenta "#da70d6"
+  - &green "#228b22"
 
 elements:
   input:
@@ -45,7 +47,7 @@ elements:
     foreground: *green
   boolean:
     foreground: *yellow
-  'null':
+  "null":
     foreground: *red
 levels:
   trace:
@@ -70,9 +72,9 @@ levels:
 indicators:
   sync:
     synced:
-      text: ' '
+      text: " "
     failed:
-      text: '!'
+      text: "!"
       inner:
         style:
           foreground: *yellow

--- a/etc/defaults/themes/uni.yaml
+++ b/etc/defaults/themes/uni.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, light, 16color]
+
 elements:
   input:
     modes: [faint]

--- a/etc/defaults/themes/universal-blue.yaml
+++ b/etc/defaults/themes/universal-blue.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, light, 16color]
+
 elements:
   input:
     modes: [faint]

--- a/etc/defaults/themes/universal.yaml
+++ b/etc/defaults/themes/universal.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 $schema: https://raw.githubusercontent.com/pamburus/hl/master/schema/json/theme.schema.json
 
+tags: [dark, light, 16color]
+
 elements:
   input:
     modes: [faint]

--- a/schema/json/theme.schema.json
+++ b/schema/json/theme.schema.json
@@ -18,6 +18,12 @@
                     },
                     "title": "Optional YAML anchors for colors"
                 },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/tag"
+                    }
+                },
                 "elements": {
                     "$ref": "#/definitions/elements"
                 },
@@ -30,6 +36,10 @@
             },
             "required": [],
             "title": "Theme"
+        },
+        "tag": {
+            "type": "string",
+            "enum": ["dark", "light", "16color", "256color", "truecolor"]
         },
         "mode": {
             "type": "string",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,9 @@
 // std imports
-use std::path::PathBuf;
+use std::{num::NonZeroUsize, path::PathBuf};
 
 // third-party imports
 use clap::{ArgAction, Args, Parser, ValueEnum, value_parser};
 use clap_complete::Shell;
-use std::num::NonZeroUsize;
 
 // local imports
 use crate::{
@@ -12,6 +11,7 @@ use crate::{
     error::*,
     level::{LevelValueParser, RelaxedLevel},
     settings::{self, InputInfo},
+    themecfg,
 };
 use enumset_ext::convert::str::EnumSet;
 
@@ -391,9 +391,9 @@ pub struct Opt {
     #[arg(long, help_heading = heading::ADVANCED)]
     pub man_page: bool,
 
-    /// Print available themes and exit.
-    #[arg(long, help_heading = heading::ADVANCED)]
-    pub list_themes: bool,
+    /// Print available themes optionally filtered by tags [dark, light, 16color, 256color, truecolor].
+    #[arg(long, num_args=0..=1, value_name = "TAGS", require_equals = true, help_heading = heading::ADVANCED)]
+    pub list_themes: Option<Option<ThemeTagSet>>,
 
     /// Print debug index metadata (in --sort mode) and exit.
     #[arg(long, requires = "sort", help_heading = heading::ADVANCED)]
@@ -445,6 +445,7 @@ pub enum FlattenOption {
 }
 
 pub type InputInfoSet = EnumSet<InputInfo>;
+pub type ThemeTagSet = EnumSet<themecfg::Tag>;
 
 mod heading {
     pub const FILTERING: &str = "Filtering Options";

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,7 @@
 // std imports
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    fmt, include_str,
+    include_str,
     ops::Deref,
     path::{Path, PathBuf},
     str::FromStr,
@@ -15,7 +15,7 @@ use enumset::{EnumSet, EnumSetType, enum_set};
 use enumset_ext::EnumSetExt;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::IntoDeserializer};
-use strum::IntoEnumIterator;
+use strum::{Display, IntoEnumIterator};
 
 // local imports
 use crate::level::{InfallibleLevel, Level};
@@ -327,7 +327,8 @@ impl Field {
 
 pub type InputInfoSet = EnumSet<InputInfo>;
 
-#[derive(Debug, Serialize, Deserialize, EnumSetType)]
+#[derive(Debug, Serialize, Deserialize, EnumSetType, Display)]
+#[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub enum InputInfo {
     Auto,
@@ -345,12 +346,6 @@ impl InputInfo {
             set
         }
         .difference(InputInfo::Auto.into())
-    }
-}
-
-impl fmt::Display for InputInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", serde_plain::to_string(self).unwrap())
     }
 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -51,7 +51,7 @@ impl Theme {
     }
 
     pub fn list(app_dirs: &AppDirs) -> Result<HashMap<Arc<str>, ThemeInfo>> {
-        themecfg::Theme::list(app_dirs)
+        Ok(themecfg::Theme::list(app_dirs)?)
     }
 
     pub fn apply<'a, B: Push<u8>, F: FnOnce(&mut Styler<'a, B>)>(


### PR DESCRIPTION
## Changes
* Added the following tags to all stock themes if applicable:
  - dark
  - light
  - 16color
  - 256color
  - truecolor

  For themes supporting both dark and light modes, both flags are set.

* Added filtering by tags in `--list-themes` as `--list-themes[=<TAGS>]`.