### PR TITLE
build(deps): updated yaml-rust2 to v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818913695e83ece1f8d2a1c52d54484b7b46d0f9c06beeb2649b9da50d9b512d"
+checksum = "18b783b2c2789414f8bb84ca3318fc9c2d7e7be1c22907d37839a58dedb369d3"
 dependencies = [
  "arraydeque",
  "encoding_rs",

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,8 +153,7 @@ mod tests {
             variant.values,
             hashmap! {
                 InfallibleLevel::new(Level::Debug) => vec!["dbg".to_owned()],
-                // TODO: replace `"inf"` with `"INF"` when https://github.com/mehcode/config-rs/issues/568 is fixed
-                InfallibleLevel::new(Level::Info) => vec!["inf".to_owned()],
+                InfallibleLevel::new(Level::Info) => vec!["INF".to_owned()],
                 InfallibleLevel::new(Level::Warning) => vec!["wrn".to_owned()],
                 InfallibleLevel::new(Level::Error) => vec!["ERR".to_owned()],
             }


### PR DESCRIPTION
Due to https://github.com/Ethiraric/yaml-rust2/pull/51, issue #288 is now correctly fixed.