### PR TITLE
feat: added distinct style configurations for false and true boolean values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.31.2"
+version = "0.32.0-alpha.1"
 dependencies = [
  "assert_matches",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.31.2"
+version = "0.32.0-alpha.1"
 edition = "2024"
 license = "MIT"
 

--- a/etc/defaults/themes/hl-dark.yaml
+++ b/etc/defaults/themes/hl-dark.yaml
@@ -34,9 +34,11 @@ elements:
   number:
     foreground: 42
   boolean:
-    foreground: 186
+    foreground: 41
+  boolean-false:
+    foreground: 210
   "null":
-    foreground: 216
+    foreground: 210
 levels:
   trace:
     level-inner:

--- a/etc/defaults/themes/hl-light.yaml
+++ b/etc/defaults/themes/hl-light.yaml
@@ -34,7 +34,9 @@ elements:
   number:
     foreground: 36
   boolean:
-    foreground: 174
+    foreground: 35
+  boolean-false:
+    foreground: 197
   "null":
     foreground: 197
 levels:

--- a/etc/defaults/themes/uni.yaml
+++ b/etc/defaults/themes/uni.yaml
@@ -34,6 +34,8 @@ elements:
     foreground: green
   boolean:
     foreground: yellow
+  boolean-false:
+    foreground: red
   "null":
     foreground: bright-red
 levels:

--- a/schema/json/theme.schema.json
+++ b/schema/json/theme.schema.json
@@ -119,6 +119,12 @@
         "boolean": {
           "$ref": "#/definitions/style"
         },
+        "boolean-false": {
+          "$ref": "#/definitions/style"
+        },
+        "boolean-true": {
+          "$ref": "#/definitions/style"
+        },
         "null": {
           "$ref": "#/definitions/style"
         },

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -433,10 +433,10 @@ impl<'a> FieldFormatter<'a> {
                 s.element(Element::Number, |s| s.batch(|buf| buf.extend(value.as_bytes())));
             }
             RawValue::Boolean(true) => {
-                s.element(Element::Boolean, |s| s.batch(|buf| buf.extend(b"true")));
+                s.element(Element::BooleanTrue, |s| s.batch(|buf| buf.extend(b"true")));
             }
             RawValue::Boolean(false) => {
-                s.element(Element::Boolean, |s| s.batch(|buf| buf.extend(b"false")));
+                s.element(Element::BooleanFalse, |s| s.batch(|buf| buf.extend(b"false")));
             }
             RawValue::Null => {
                 s.element(Element::Null, |s| s.batch(|buf| buf.extend(b"null")));

--- a/src/testing/assets/themes/test.toml
+++ b/src/testing/assets/themes/test.toml
@@ -43,6 +43,9 @@ foreground = "bright-blue"
 [elements.boolean]
 foreground = "bright-green"
 
+[elements.boolean-false]
+foreground = "bright-red"
+
 [elements.null]
 foreground = "bright-red"
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -279,14 +279,27 @@ impl StylePack {
 
     fn load(s: &themecfg::StylePack) -> Self {
         let mut result = Self::default();
+
         let items = s.items();
         if items.len() != 0 {
             result.styles.push(Style::reset());
             result.reset = Some(0);
         }
+
         for (&element, style) in s.items() {
             result.add(element, &Style::from(style))
         }
+
+        if let Some(base) = s.items().get(&Element::Boolean) {
+            for variant in [Element::BooleanTrue, Element::BooleanFalse] {
+                let mut style = base.clone();
+                if let Some(patch) = s.items().get(&variant) {
+                    style = style.merged(patch)
+                }
+                result.add(variant, &Style::from(&style));
+            }
+        }
+
         result
     }
 }

--- a/src/themecfg.rs
+++ b/src/themecfg.rs
@@ -402,6 +402,8 @@ pub enum Element {
     String,
     Number,
     Boolean,
+    BooleanTrue,
+    BooleanFalse,
     Null,
     Ellipsis,
 }
@@ -415,6 +417,21 @@ pub struct Style {
     pub modes: Vec<Mode>,
     pub foreground: Option<Color>,
     pub background: Option<Color>,
+}
+
+impl Style {
+    pub fn merged(mut self, other: &Self) -> Self {
+        if other.modes.len() != 0 {
+            self.modes = other.modes.clone()
+        }
+        if let Some(color) = other.foreground {
+            self.foreground = Some(color);
+        }
+        if let Some(color) = other.background {
+            self.background = Some(color);
+        }
+        self
+    }
 }
 
 // ---
@@ -719,5 +736,38 @@ mod tests {
         assert_eq!(Tag::from_str("256color").unwrap(), Tag::Palette256);
         assert_eq!(Tag::from_str("truecolor").unwrap(), Tag::TrueColor);
         assert!(Tag::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_style_merge() {
+        let base = Style {
+            modes: vec![Mode::Bold],
+            foreground: Some(Color::Plain(PlainColor::Red)),
+            background: Some(Color::Plain(PlainColor::Blue)),
+        };
+
+        let patch = Style {
+            modes: vec![Mode::Italic],
+            foreground: Some(Color::Plain(PlainColor::Green)),
+            background: None,
+        };
+
+        let result = base.clone().merged(&patch);
+
+        assert_eq!(result.modes, vec![Mode::Italic]);
+        assert_eq!(result.foreground, Some(Color::Plain(PlainColor::Green)));
+        assert_eq!(result.background, Some(Color::Plain(PlainColor::Blue)));
+
+        let patch = Style {
+            modes: vec![],
+            foreground: None,
+            background: Some(Color::Plain(PlainColor::Green)),
+        };
+
+        let result = base.clone().merged(&patch);
+
+        assert_eq!(result.modes, vec![Mode::Bold]);
+        assert_eq!(result.foreground, Some(Color::Plain(PlainColor::Red)));
+        assert_eq!(result.background, Some(Color::Plain(PlainColor::Green)));
     }
 }


### PR DESCRIPTION
Closes #944

Adds support for optional `boolean-true` and `boolean-false` elements in themes.
If specified, settings in these elements override corresponding settings in the `boolean` element.

Changes `false` value color in `uni`, `hl-dark` and `hl-light` themes to red.
Changes `true` value color in `hl-dark` and `hl-light` themes to green.