### PR TITLE
feat: added message format setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.32.0-alpha.3"
+version = "0.32.0-alpha.4"
 dependencies = [
  "assert_matches",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.32.0-alpha.3"
+version = "0.32.0-alpha.4"
 edition = "2024"
 license = "MIT"
 

--- a/etc/defaults/config.yaml
+++ b/etc/defaults/config.yaml
@@ -73,7 +73,17 @@ fields:
 
 # Formatting settings.
 formatting:
+  # Flatten nested fields by joining them with a dot. Options: [always, never].
   flatten: always
+  message:
+    # Message format [auto-quoted, always-quoted, always-double-quoted, delimited, raw]:
+    # * "auto-quoted"          • Automatically enables or disables message quotation to improve clarity or avoid ambiguities.
+    # * "always-quoted"        • Always prints messages in most appropriate to align them consistently and yet maintain readability.
+    # * "always-double-quoted" • Always prints messages in double quotes to align them consistently.
+    # * "delimited"            • Separates the message from fields with a supposedly rare delimiter to avoid quotation in most cases and avoid ambiguities at the same time.
+    #                            See [formatting.punctuation.message-delimiter] setting.
+    # * "raw"                  • Always prints messages without any quotes, escaping or delimiters.
+    format: delimited
   punctuation:
     logger-name-separator: ":"
     field-key-value-separator: "="
@@ -92,6 +102,9 @@ formatting:
     input-name-clipping: "··"
     input-name-common-part: "··"
     array-separator: " "
+    # Delimiter used between message and fields when "delimited" message format is used.
+    # See [formatting.message.format] for more details.
+    message-delimiter: "::"
 
 # Number of processing threads, configured automatically based on CPU count if not specified.
 concurrency: ~

--- a/etc/defaults/themes/ayu-dark-24.yaml
+++ b/etc/defaults/themes/ayu-dark-24.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: "#3f5d7f"
   message:
     foreground: "#95e6cb"
+  message-delimiter:
+    foreground: "#565b66"
   field:
     foreground: "#3f5d7f"
   key:

--- a/etc/defaults/themes/ayu-light-24.yaml
+++ b/etc/defaults/themes/ayu-light-24.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: "#a8caf1"
   message:
     foreground: "#5c6166"
+  message-delimiter:
+    foreground: "#a7aaad"
   field:
     foreground: "#478acc"
   key:

--- a/etc/defaults/themes/ayu-mirage-24.yaml
+++ b/etc/defaults/themes/ayu-mirage-24.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: "#707a8c"
   message:
     foreground: "#95e6cb"
+  message-delimiter:
+    foreground: "#707a8c"
   field:
     foreground: "#4e6c90"
   key:

--- a/etc/defaults/themes/classic-light.yaml
+++ b/etc/defaults/themes/classic-light.yaml
@@ -16,6 +16,8 @@ elements:
     foreground: default
   message:
     foreground: black
+  message-delimiter:
+    foreground: bright-black
   field:
     foreground: bright-black
   key:

--- a/etc/defaults/themes/classic-plus.yaml
+++ b/etc/defaults/themes/classic-plus.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: bright-black
   message:
     foreground: default
+  message-delimiter:
+    foreground: bright-black
   field:
     foreground: bright-black
   key:

--- a/etc/defaults/themes/classic.yaml
+++ b/etc/defaults/themes/classic.yaml
@@ -16,6 +16,8 @@ elements:
     foreground: default
   message:
     foreground: bright-white
+  message-delimiter:
+    foreground: bright-black
   field:
     foreground: bright-black
   key:

--- a/etc/defaults/themes/dmt.yaml
+++ b/etc/defaults/themes/dmt.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: 139
   message:
     foreground: default
+  message-delimiter:
+    foreground: 8
   field:
     foreground: 60
   key:

--- a/etc/defaults/themes/hl-dark.yaml
+++ b/etc/defaults/themes/hl-dark.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: 30
   message:
     foreground: 195
+  message-delimiter:
+    foreground: 30
   field:
     foreground: 30
   key:

--- a/etc/defaults/themes/hl-light.yaml
+++ b/etc/defaults/themes/hl-light.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: 30
   message:
     foreground: 16
+  message-delimiter:
+    foreground: 30
   field:
     foreground: 30
   key:

--- a/etc/defaults/themes/lsd.yaml
+++ b/etc/defaults/themes/lsd.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: bright-black
   message:
     foreground: default
+  message-delimiter:
+    foreground: bright-black
   field:
     foreground: default
   key:

--- a/etc/defaults/themes/neutral.yaml
+++ b/etc/defaults/themes/neutral.yaml
@@ -18,6 +18,8 @@ elements:
   message:
     foreground: default
     modes: [bold]
+  message-delimiter:
+    modes: [faint]
   field:
     modes: [faint]
   key:

--- a/etc/defaults/themes/one-dark-24.yaml
+++ b/etc/defaults/themes/one-dark-24.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: "#476a8c"
   message:
     foreground: "#abb2bf"
+  message-delimiter:
+    foreground: "#666b76"
   field:
     foreground: "#476a8c"
   key:

--- a/etc/defaults/themes/one-light-24.yaml
+++ b/etc/defaults/themes/one-light-24.yaml
@@ -17,6 +17,8 @@ elements:
     foreground: "#a0a1a7"
   message:
     foreground: "#383a42"
+  message-delimiter:
+    foreground: "#a0a1a7"
   field:
     foreground: "#a0a1a7"
   key:

--- a/etc/defaults/themes/tc24d-b2.yaml
+++ b/etc/defaults/themes/tc24d-b2.yaml
@@ -28,6 +28,8 @@ elements:
     foreground: *gray
   message:
     foreground: *strong
+  message-delimiter:
+    foreground: *gray
   field:
     foreground: *gray
   key:

--- a/etc/defaults/themes/tc24d-blue.yaml
+++ b/etc/defaults/themes/tc24d-blue.yaml
@@ -29,6 +29,8 @@ elements:
   message:
     foreground: *strong
     modes: [bold]
+  message-delimiter:
+    foreground: *gray
   field:
     foreground: *gray
   key:

--- a/etc/defaults/themes/tc24l-b2.yaml
+++ b/etc/defaults/themes/tc24l-b2.yaml
@@ -28,6 +28,8 @@ elements:
     foreground: *gray
   message:
     foreground: *strong
+  message-delimiter:
+    foreground: *gray
   field:
     foreground: *gray
   key:

--- a/etc/defaults/themes/tc24l-blue.yaml
+++ b/etc/defaults/themes/tc24l-blue.yaml
@@ -29,6 +29,8 @@ elements:
   message:
     foreground: *strong
     modes: [bold]
+  message-delimiter:
+    foreground: *gray
   field:
     foreground: *gray
   key:

--- a/etc/defaults/themes/uni.yaml
+++ b/etc/defaults/themes/uni.yaml
@@ -18,6 +18,8 @@ elements:
   message:
     foreground: default
     modes: [bold]
+  message-delimiter:
+    modes: [faint]
   field:
     modes: [faint]
   key:

--- a/etc/defaults/themes/universal-blue.yaml
+++ b/etc/defaults/themes/universal-blue.yaml
@@ -18,6 +18,8 @@ elements:
   message:
     foreground: default
     modes: [bold]
+  message-delimiter:
+    modes: [faint]
   field:
     modes: [faint]
   key:

--- a/etc/defaults/themes/universal.yaml
+++ b/etc/defaults/themes/universal.yaml
@@ -18,6 +18,8 @@ elements:
   message:
     foreground: default
     modes: [bold]
+  message-delimiter:
+    modes: [faint]
   field:
     modes: [faint]
   key:

--- a/schema/json/config.schema.json
+++ b/schema/json/config.schema.json
@@ -214,6 +214,21 @@
           "type": "string",
           "enum": ["never", "always"]
         },
+        "message": {
+          "type": "object",
+          "properties": {
+            "style": {
+              "type": "string",
+              "enum": [
+                "auto-quoted",
+                "always-quoted",
+                "always-double-quoted",
+                "delimited",
+                "raw"
+              ]
+            }
+          }
+        },
         "punctuation": {
           "type": "object",
           "additionalProperties": false,
@@ -267,6 +282,9 @@
               "type": "string"
             },
             "array-separator": {
+              "type": "string"
+            },
+            "message-delimiter": {
               "type": "string"
             }
           }

--- a/schema/json/theme.schema.json
+++ b/schema/json/theme.schema.json
@@ -98,6 +98,9 @@
         "message": {
           "$ref": "#/definitions/style"
         },
+        "message-delimiter": {
+          "$ref": "#/definitions/style"
+        },
         "field": {
           "$ref": "#/definitions/style"
         },

--- a/src/app.rs
+++ b/src/app.rs
@@ -1120,7 +1120,7 @@ mod tests {
         filtering::MatchOptions,
         level::{InfallibleLevel, Level},
         model::FieldFilterSet,
-        settings,
+        settings::{self, MessageFormat, MessageFormatting},
         themecfg::testing,
     };
 
@@ -1486,7 +1486,12 @@ mod tests {
             concurrency: 1,
             filter: Default::default(),
             fields: FieldOptions::default(),
-            formatting: Formatting::default(),
+            formatting: Formatting {
+                message: MessageFormatting {
+                    format: MessageFormat::AutoQuoted,
+                },
+                ..Formatting::default()
+            },
             time_zone: Tz::IANA(UTC),
             hide_empty_fields: false,
             sort: false,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -365,8 +365,30 @@ impl FromStr for InputInfo {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Formatting {
-    pub punctuation: Punctuation,
     pub flatten: Option<FlattenOption>,
+    pub message: MessageFormatting,
+    pub punctuation: Punctuation,
+}
+
+// ---
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct MessageFormatting {
+    pub format: MessageFormat,
+}
+
+// ---
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum MessageFormat {
+    AutoQuoted,
+    AlwaysQuoted,
+    AlwaysDoubleQuoted,
+    #[default]
+    Delimited,
+    Raw,
 }
 
 // ---
@@ -380,17 +402,12 @@ pub enum FlattenOption {
 
 // ---
 
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum FieldShowOption {
+    #[default]
     Auto,
     Always,
-}
-
-impl Default for FieldShowOption {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 // ---
@@ -415,6 +432,7 @@ pub struct Punctuation {
     pub input_name_clipping: String,
     pub input_name_common_part: String,
     pub array_separator: String,
+    pub message_delimiter: String,
 }
 
 impl Default for Punctuation {
@@ -437,6 +455,7 @@ impl Default for Punctuation {
             input_name_clipping: "...".into(),
             input_name_common_part: "...".into(),
             array_separator: " ".into(),
+            message_delimiter: "::".into(),
         }
     }
 }
@@ -462,6 +481,7 @@ impl Punctuation {
             input_name_clipping: "...".into(),
             input_name_common_part: "...".into(),
             array_separator: ",".into(),
+            message_delimiter: "::".into(),
         }
     }
 }

--- a/src/testing/assets/themes/test.toml
+++ b/src/testing/assets/themes/test.toml
@@ -19,6 +19,9 @@ foreground = "cyan"
 foreground = "default"
 modes = ["bold"]
 
+[elements.message-delimiter]
+modes = ["faint", "italic"]
+
 [elements.field]
 modes = ["faint"]
 

--- a/src/themecfg.rs
+++ b/src/themecfg.rs
@@ -395,6 +395,7 @@ pub enum Element {
     Caller,
     CallerInner,
     Message,
+    MessageDelimiter,
     Field,
     Key,
     Array,


### PR DESCRIPTION
This pull request adds the following options to the configuration file:
```yaml
# Formatting settings.
formatting:
  message:
    # Message format [auto-quoted, always-quoted, always-double-quoted, delimited, raw]:
    # * "auto-quoted"          • Automatically enables or disables message quotation to improve clarity or avoid ambiguities.
    # * "always-quoted"        • Always prints messages in most appropriate to align them consistently and yet maintain readability.
    # * "always-double-quoted" • Always prints messages in double quotes to align them consistently.
    # * "delimited"            • Separates the message from fields with a supposedly rare delimiter to avoid quotation in most cases and avoid ambiguities at the same time.
    #                            See [formatting.punctuation.message-delimiter] setting.
    # * "raw"                  • Always prints messages without any quotes, escaping or delimiters.
    format: delimited
  punctuation:
    # Delimiter used between message and fields when "delimited" message format is used.
    # See [formatting.message.format] for more details.
    message-delimiter: "::"
```

This also changes the default message format to `delimited`, which improves readability when `=` or various quotation marks are used in messages, while avoiding ambiguity in most cases.

If you don't like the new default formatting style, you can opt out and revert to the previous style by setting `formatting.message.format` to `auto-quoted`.

If you don't care about ambiguity and want to avoid quotation marks and escaping, set `formatting.message.format` to `raw`.

Closes #907 