### PR TITLE
feat: added filtering by array items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.debug
 /.vscode
+/.zed
 /*.log
 /*.log.bz2
 /*.log.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.32.0-alpha.4"
+version = "0.32.0-alpha.5"
 dependencies = [
  "assert_matches",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.32.0-alpha.4"
+version = "0.32.0-alpha.5"
 edition = "2024"
 license = "MIT"
 

--- a/src/query.pest
+++ b/src/query.pest
@@ -17,7 +17,7 @@ _ff_rhs_num_1 = _{ _ff_num_op_1 ~ ws* ~ number }
 _ff_rhs_num_n = _{ _ff_num_op_n ~ ws* ~ number_set }
 _ff_rhs_str_1 = _{ _ff_str_op_1 ~ ws* ~ string }
 _ff_rhs_str_n = _{ _ff_str_op_n ~ ws* ~ string_set }
-_f_name_short = @{ ("@" | "_" | "-" | "." | LETTER | NUMBER)+ }
+_f_name_short = @{ ("@" | "_" | "-" | "." | LETTER | NUMBER | "[" | "]")+ }
 
 level = ${
     string ~ &punctuation


### PR DESCRIPTION
Adds support for filtering by array items.

Supported variants include
* Matching any item in the array
   ```
    hl -f 'span.[].name=a'
    ```
* Matching an exact item in the array 
   ```
    hl -f 'span.[0].name=a'
    ```

Closes #964 