### PR TITLE
chore: replace `term_size` with `terminal_size`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.32.0-alpha.8"
+version = "0.32.0-alpha.9"
 dependencies = [
  "assert_matches",
  "base32",
@@ -1127,7 +1127,7 @@ dependencies = [
  "stats_alloc",
  "strsim",
  "strum",
- "term_size",
+ "terminal_size",
  "thiserror 2.0.16",
  "titlecase",
  "toml",
@@ -2208,16 +2208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,22 +2530,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39b7d07a236abaef6607536ccfaf19b396dbe3f5110ddb73d39f4562902ed382"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,12 +2537,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.32.0-alpha.8"
+version = "0.32.0-alpha.9"
 edition = "2024"
 license = "MIT"
 
@@ -91,7 +91,7 @@ signal-hook = "0.3"
 snap = "1"
 strsim = "0.11"
 strum = { version = "0.27", features = ["derive"] }
-term_size = "0.3"
+terminal_size = "0.4"
 thiserror = "2"
 titlecase = "3"
 toml = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use enumset::enum_set;
 use enumset_ext::EnumSetExt;
 use env_logger::{self as logger};
 use itertools::Itertools;
+use terminal_size::terminal_size_of;
 use utf8_supported::{Utf8Support, utf8_supported};
 
 // local imports
@@ -212,7 +213,7 @@ fn run() -> Result<()> {
         log::debug!("configured input info layouts: {input_info}");
         input_info = InputInfo::resolve(input_info);
         log::debug!("* resolved input info layouts: {input_info}");
-        match term_size::dimensions_stdout().map(|(w, _)| w) {
+        match terminal_size_of(stdout()).map(|(w, _)| w.0) {
             None => {
                 log::debug!("* no terminal detected");
             }


### PR DESCRIPTION
Reason: [RUSTSEC-2020-0163](https://rustsec.org/advisories/RUSTSEC-2020-0163).