### PR TITLE
Revert "build(deps): bump heapless from 0.8.0 to 0.9.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.9.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
  "stable_deref_trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ enumset-ext = { path = "./crate/enumset-ext", features = ["serde", "clap"] }
 enumset-serde = { path = "./crate/enumset-serde" }
 env_logger = "0.11"
 flate2 = "1"
-heapless = "0.9"
+heapless = "0.8"
 heapopt = { path = "./crate/heapopt" }
 hex = "0.4"
 htp = { git = "https://github.com/pamburus/htp.git" }


### PR DESCRIPTION
Reverts pamburus/hl#999

Reason: introduced build failures
{noformat}
building '/nix/store/lai3cnfxqz72jqi0j909j539dyimnqqx-hl-0.32.0-alpha.10.drv'...
error: builder for '/nix/store/lai3cnfxqz72jqi0j909j539dyimnqqx-hl-0.32.0-alpha.10.drv' failed with exit code 101;
       last 25 log lines:
       >   17:     0x7ffff34b8e80 - rustc_span[b1ac4e9644d21f98]::create_session_globals_then::<(), rustc_interface[eb0613cadd461d93]::util::run_in_thread_with_globals<rustc_interface[eb0613cadd461d93]::util::run_in_thread_pool_with_globals<rustc_interface[eb0613cadd461d93]::interface::run_compiler<(), rustc_driver_impl[470edcfae8897e81]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}::{closure#0}>
       >   18:     0x7ffff3537fa2 - std[2c7d8812d54178b9]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[eb0613cadd461d93]::util::run_in_thread_with_globals<rustc_interface[eb0613cadd461d93]::util::run_in_thread_pool_with_globals<rustc_interface[eb0613cadd461d93]::interface::run_compiler<(), rustc_driver_impl[470edcfae8897e81]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
       >   19:     0x7ffff353ada3 - <<std[2c7d8812d54178b9]::thread::Builder>::spawn_unchecked_<rustc_interface[eb0613cadd461d93]::util::run_in_thread_with_globals<rustc_interface[eb0613cadd461d93]::util::run_in_thread_pool_with_globals<rustc_interface[eb0613cadd461d93]::interface::run_compiler<(), rustc_driver_impl[470edcfae8897e81]::run_compiler::{closure#0}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[15a17bea78b37a3e]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
       >   20:     0x7ffff696b9db - std::sys::pal::unix::thread::Thread::new::thread_start::hae1868b1dcc0da67
       >   21:     0x7ffff2897e63 - start_thread
       >   22:     0x7ffff291bdbc - __clone3
       >   23:                0x0 - <unknown>
       >
       > error: the compiler unexpectedly panicked. this is a bug.
       >
       > note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md
       >
       > note: rustc 1.86.0 (05f9846f8 2025-03-31) (built from a source tarball) running on x86_64-unknown-linux-gnu
       >
       > note: compiler flags: --crate-type lib -C opt-level=3 -C linker-plugin-lto -C codegen-units=1 -C linker=/nix/store/0fsnicvfpf55nkza12cjnad0w84d6ba7-gcc-wrapper-14.2.1.20250322/bin/cc -C target-feature=-crt-static
       >
       > note: some of the compiler flags provided by cargo are hidden
       >
       > query stack during panic:
       > end of query stack
       > error: could not compile `heapless` (lib)
       >
       > Caused by:
       >   process didn't exit successfully: `rustc --crate-name heapless --edition=2021 /build/cargo-vendor-dir/heapless-0.9.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C linker-plugin-lto -C codegen-units=1 --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("alloc", "bytes", "defmt", "mpmc_large", "nightly", "portable-atomic", "portable-atomic-critical-section", "portable-atomic-unsafe-assume-single-core", "serde", "ufmt"))' -C metadata=21cf401ad598c745 -C extra-filename=-bcfe147247289ea1 --out-dir /build/326ghw55i527bvhf3g12vcjapp4ix5w0-source/target/x86_64-unknown-linux-gnu/release/deps --target x86_64-unknown-linux-gnu -C linker=/nix/store/0fsnicvfpf55nkza12cjnad0w84d6ba7-gcc-wrapper-14.2.1.20250322/bin/cc -L dependency=/build/326ghw55i527bvhf3g12vcjapp4ix5w0-source/target/x86_64-unknown-linux-gnu/release/deps -L dependency=/build/326ghw55i527bvhf3g12vcjapp4ix5w0-source/target/release/deps --extern hash32=/build/326ghw55i527bvhf3g12vcjapp4ix5w0-source/target/x86_64-unknown-linux-gnu/release/deps/libhash32-f673388da3775a32.rmeta --extern stable_deref_trait=/build/326ghw55i527bvhf3g12vcjapp4ix5w0-source/target/x86_64-unknown-linux-gnu/release/deps/libstable_deref_trait-91fa7cb46e43777e.rmeta --cap-lints allow -C target-feature=-crt-static --check-cfg 'cfg(arm_llsc)' --check-cfg 'cfg(has_atomic_load_store)'` (exit status: 101)
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run:
         nix log /nix/store/lai3cnfxqz72jqi0j909j539dyimnqqx-hl-0.32.0-alpha.10.drv
error: 1 dependencies of derivation '/nix/store/843jzjbczr1kr0x391w748i01szb6gss-system-path.drv' failed to build
{noformat}