### PR TITLE
feat(nix): added binary nix package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.32.1-alpha.3"
+version = "0.32.1-alpha.4"
 dependencies = [
  "assert_matches",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.32.1-alpha.3"
+version = "0.32.1-alpha.4"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -138,40 +138,85 @@ High-performance log viewer and processor that transforms logs in JSON and logfm
   nix run github:pamburus/hl
   ```
 
-  or install with [nix profile](https://nix.dev/manual/nix/2.22/command-ref/new-cli/nix3-profile-install):
+  or binary package
 
   ```sh
-  nix profile install github:pamburus/hl
+  nix run github:pamburus/hl#bin
   ```
 
-* Install the package using [nix-flakes](https://wiki.nixos.org/wiki/Flakes)
+  or install with [nix profile](https://nix.dev/manual/nix/2.31/command-ref/new-cli/nix3-profile-add):
+
+  ```sh
+  nix profile add github:pamburus/hl
+  ```
+
+  or binary package
+
+  ```sh
+  nix profile add github:pamburus/hl#bin
+  ```
+
+* Install the package from source using [nix-flakes](https://wiki.nixos.org/wiki/Flakes)
 
   <details>
   <summary>Example how to update nix configuration</summary>
 
   ```nix
   {
-      inputs = {
-          nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-          hl.url = "github:pamburus/hl";
+    inputs = {
+      nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+      hl.url = "github:pamburus/hl";
+    };
+    outputs = {nixpkgs, hl, ...}:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      # this is just an example!
+      nixosConfigurations.yourHost = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ({...}: {
+            environment.systemPackages = [
+              hl.packages.${system}
+            ];
+          })
+        ];
       };
-      outputs = {nixpkgs, hl, ...}:
-      let
-          system = "x86_64-linux";
-      in
-      {
-          # this is just an example!
-          nixosConfigurations.yourHost = nixpkgs.lib.nixosSystem {
-              inherit system;
-              modules = [
-                  ({...}: {
-                    environment.systemPackages = [
-                      hl.packages.${system}
-                    ];
-                  })
-              ];
-          };
+    };
+  }
+  ```
+
+  </details>
+
+* Install the package with pre-built binaries using [nix-flakes](https://wiki.nixos.org/wiki/Flakes)
+
+  <details>
+  <summary>Example how to update nix configuration</summary>
+
+  ```nix
+  {
+    inputs = {
+      nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+      hl.url = "github:pamburus/hl";
+    };
+    outputs = {nixpkgs, hl, ...}:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      # this is just an example!
+      nixosConfigurations.yourHost = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ({...}: {
+            environment.systemPackages = [
+              hl.packages.${system}.bin
+            ];
+          })
+        ];
       };
+    };
   }
   ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,10 @@
             overlays = [ inputs.rust-overlay.overlays.default ];
           };
 
-          packages.default = pkgs.callPackage ./nix/package.nix { };
+          packages = {
+            default = pkgs.callPackage ./nix/package.nix { };
+            bin = pkgs.callPackage ./nix/binary-package.nix { };
+          };
 
           devShells.default = self'.packages.default;
         };

--- a/justfile
+++ b/justfile
@@ -141,9 +141,7 @@ nix-update:
 # Build all defined Nix package variants
 nix-build-all:
     nix build .#hl
-    nix build .#hl-debug
-    nix build .#hl-static
-    nix build .#hl-minimal
+    nix build .#hl-bin
 
 # Show the dependency tree of the Nix derivation
 nix-deps:

--- a/nix/binary-hashes.nix
+++ b/nix/binary-hashes.nix
@@ -1,0 +1,8 @@
+{
+  "0.32.0" = {
+    "hl-linux-arm64-musl.tar.gz" = "sha256-lbmJF9ECksCL/A0QMysTyQjOwVLi4hyOB0uFzpYA1Cs=";
+    "hl-linux-x86_64-musl.tar.gz" = "sha256-NvatH7J5/xjd/vmhE6CKe6BIC17b4+AQIS2OOFDgUxA=";
+    "hl-macos-arm64.tar.gz" = "sha256-1rXrkfEskNErb1Tf7IepyerUPsyQJ1gpR+5IScJCTcg=";
+    "hl-macos-x86_64.tar.gz" = "sha256-kcf18Us6KKAzdhTv98ashNTBJRDq1dBEJztJMoOUnso=";
+  };
+}

--- a/nix/binary-package.nix
+++ b/nix/binary-package.nix
@@ -1,0 +1,105 @@
+{ lib, stdenv, fetchurl, installShellFiles }:
+
+let
+  # Get the current version from Cargo.toml (for metadata only)
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+
+  # Import release hashes from separate file (automatically updated by GitHub Actions)
+  releaseHashes = import ./binary-hashes.nix;
+
+  # Get the highest version available in binary-hashes.nix
+  availableVersions = builtins.attrNames releaseHashes;
+
+  # Fail if no versions are available in binary-hashes.nix
+  version = if availableVersions == []
+           then throw "No versions available in binary-hashes.nix - package configuration is inconsistent"
+           else builtins.foldl' (acc: v:
+             if builtins.compareVersions v acc > 0 then v else acc
+           ) (builtins.head availableVersions) availableVersions;
+
+  # Map Nix system to asset name
+  getAssetName = system:
+    {
+      "x86_64-linux" = "hl-linux-x86_64-musl.tar.gz";
+      "aarch64-linux" = "hl-linux-arm64-musl.tar.gz";
+      "x86_64-darwin" = "hl-macos-x86_64.tar.gz";
+      "aarch64-darwin" = "hl-macos-arm64.tar.gz";
+    }.${system} or (throw "Unsupported system: ${system}");
+
+  # Build the download URL
+  assetName = getAssetName stdenv.hostPlatform.system;
+  downloadUrl = "https://github.com/pamburus/hl/releases/download/v${version}/${assetName}";
+
+  # Get hash for the current version and asset
+  assetHash = releaseHashes.${version}.${assetName} or
+    (throw "No hash available for version ${version} and asset ${assetName} - package configuration is inconsistent");
+
+  # Fetch the binary
+  src = fetchurl {
+    url = downloadUrl;
+    sha256 = assetHash;
+  };
+
+in
+stdenv.mkDerivation {
+  pname = "hl-bin";
+  inherit version;
+
+  inherit src;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    case "$src" in
+      *.tar.gz)
+        tar -xzf "$src"
+        ;;
+      *.zip)
+        unzip "$src"
+        ;;
+      *)
+        echo "Unsupported archive format"
+        exit 1
+        ;;
+    esac
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install the binary
+    install -D -m755 hl $out/bin/hl
+
+    # Generate and install shell completions
+    installShellCompletion --cmd hl \
+      --bash <($out/bin/hl --shell-completions bash) \
+      --fish <($out/bin/hl --shell-completions fish) \
+      --zsh <($out/bin/hl --shell-completions zsh)
+
+    # Generate and install man page
+    $out/bin/hl --man-page >hl.1
+    installManPage hl.1
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "${cargoToml.package.description} (binary distribution)";
+    homepage = cargoToml.workspace.package.repository;
+    license = lib.licenses.mit;
+    changelog = "${cargoToml.workspace.package.repository}/releases";
+    maintainers = [
+      {
+        name = "Pavel Ivanov";
+        github = "pamburus";
+        email = "mr.pavel.ivanov@gmail.com";
+      }
+    ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    mainProgram = "hl";
+  };
+}


### PR DESCRIPTION
This pull request adds a binary package `bin` for Nix which uses pre-built binaries from [releases](https://github.com/pamburus/hl/releases).

## Benefits

The binary package offers:
- **Faster installation** - No compilation required
- **Reduced dependencies** - No need for Rust toolchain
- **Consistent builds** - Uses the same binaries as GitHub releases

## Usage

Run directly:
  ```sh
  nix run github:pamburus/hl#bin
  ```

Add to profile:
  ```sh
  nix profile add github:pamburus/hl#bin
  ```

Add to NixOS system configuration:
  ```nix
  {
    inputs = {
      nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
      hl.url = "github:pamburus/hl";
    };
    outputs = {nixpkgs, hl, ...}:
    let
      system = "x86_64-linux";
    in
    {
      # this is just an example!
      nixosConfigurations.yourHost = nixpkgs.lib.nixosSystem {
        inherit system;
        modules = [
          ({...}: {
            environment.systemPackages = [
              hl.packages.${system}.bin
            ];
          })
        ];
      };
    };
  }
  ```