### PR TITLE
build(release): added release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,17 @@
-name: Publish
+name: Build
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_call:
+    inputs:
+      release:
+        description: "Release tag or identifier"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to build from"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -11,8 +19,8 @@ permissions:
   actions: read
 
 jobs:
-  publish:
-    name: Publish for ${{ matrix.name }}
+  build:
+    name: Build for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
     env:
@@ -101,6 +109,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -142,8 +152,7 @@ jobs:
         run: tar -C ./target -cz -f ${{ matrix.asset }} hl
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.asset }}
-          tag: ${{ github.ref }}
+        run: |
+          gh release upload "${{ inputs.release }}" "${{ matrix.asset }}" --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,197 @@
+name: Release
+
+defaults:
+  run:
+    shell: bash -euxo pipefail {0}
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Release type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  issues: read
+  actions: read
+
+jobs:
+  prepare-release:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.update-version.outputs.version }}
+      release-tag: ${{ steps.create-release.outputs.release-tag }}
+      temp-branch: ${{ steps.create-temp-branch.outputs.branch }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create temporary branch
+        id: create-temp-branch
+        run: |
+          TEMP_BRANCH="release-prep-$(date +%s)"
+          git checkout -b "${TEMP_BRANCH:?}"
+          echo "branch=${TEMP_BRANCH:?}" >> $GITHUB_OUTPUT
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          rustflags: ""
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+
+      - name: Update version in Cargo.toml
+        id: update-version
+        run: |
+          cargo set-version --package hl --bump "${{ github.event.inputs.release-type }}"
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "hl") | .version')
+          echo "version=${VERSION?}" >> $GITHUB_OUTPUT
+
+      - name: Install git-cliff
+        run: |
+          # Install git-cliff for generating release notes
+          CLIFF_VERSION="2.10.1"
+          curl -sSfL "https://github.com/orhun/git-cliff/releases/download/v${CLIFF_VERSION}/git-cliff-${CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz
+          sudo mv git-cliff-*/git-cliff /usr/local/bin/
+          git-cliff --version
+
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          VERSION=${{ steps.update-version.outputs.version }}
+          PREVIOUS_TAG=$(git tag -l "v*.*.*" --merged HEAD --sort=-version:refname | head -1 || echo "")
+          git-cliff --tag "v${VERSION:?}" --output RELEASE_NOTES.md --verbose "${PREVIOUS_TAG:?}..HEAD"
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Create draft release
+        id: create-release
+        run: |
+          VERSION=${{ steps.update-version.outputs.version }}
+          gh release create "v${VERSION:?}" \
+            --title "v${VERSION:?}" \
+            --notes-file RELEASE_NOTES.md \
+            --draft
+          echo "release-tag=v${VERSION:?}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Commit version update
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): bump version to ${{ steps.update-version.outputs.version }}"
+          git push origin "refs/heads/${{ steps.create-temp-branch.outputs.branch }}"
+
+  build:
+    name: Build and Upload Binaries
+    needs: prepare-release
+    uses: ./.github/workflows/build.yml
+    with:
+      release: ${{ needs.prepare-release.outputs.release-tag }}
+      ref: ${{ needs.prepare-release.outputs.temp-branch }}
+    permissions:
+      contents: write
+      issues: read
+      actions: read
+
+  finalize-release:
+    name: Finalize Release
+    runs-on: ubuntu-latest
+    needs: [prepare-release, build]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+          ref: ${{ needs.prepare-release.outputs.temp-branch }}
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Generate Nix binary hashes file
+        run: |
+          VERSION=${{ needs.prepare-release.outputs.version }}
+          RELEASE_TAG=${{ needs.prepare-release.outputs.release-tag }}
+
+          # Install nixfmt for pretty formatting
+          nix profile add nixpkgs#nixfmt
+
+          # Get filtered assets and convert hex hashes to SRI format
+          gh release view "${RELEASE_TAG:?}" --json assets --jq '.assets
+            | map(select(.name | test("^hl-(linux-(x86_64|arm64)-musl|macos-(x86_64|arm64))\\.tar\\.gz$")))
+            | .[] | .name + ":" + (.digest | ltrimstr("sha256:"))' | \
+            while IFS=':' read -r name hex; do
+              echo "${name:?}:sha256-$(echo -n "${hex:?}" | xxd -r -p | base64)"
+            done > /tmp/assets-sri.txt
+
+          # Convert SRI hashes to JSON format
+          jq -R -s --arg version "${VERSION:?}" '
+            {($version): (
+              split("\n")
+              | map(select(length > 0) | split(":") | {key: .[0], value: .[1]})
+              | from_entries
+            )}' < /tmp/assets-sri.txt > /tmp/hashes.json
+
+          # Convert JSON to Nix and format
+          nix eval --impure --expr 'builtins.fromJSON (builtins.readFile "/tmp/hashes.json")' | \
+            nixfmt > nix/binary-hashes.nix
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Commit hash updates and create final tag
+        run: |
+          VERSION=${{ needs.prepare-release.outputs.version }}
+
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          git add nix/binary-hashes.nix
+          git commit -m "build(nix): update binary hashes for v${VERSION:?}"
+
+          # Create final tag pointing to commit with all changes
+          git tag "v${VERSION:?}"
+
+      - name: Fast-forward target branch and publish release
+        run: |
+          VERSION=${{ needs.prepare-release.outputs.version }}
+          RELEASE_TAG=${{ needs.prepare-release.outputs.release-tag }}
+          TEMP_BRANCH=${{ needs.prepare-release.outputs.temp-branch }}
+          TARGET_BRANCH=${{ github.ref_name }}
+
+          git checkout -B "${TARGET_BRANCH:?}" "origin/${TARGET_BRANCH:?}"
+
+          git merge --ff-only "refs/heads/${TEMP_BRANCH:?}"
+          git push origin "refs/heads/${TARGET_BRANCH:?}"
+          git push origin "refs/tags/v${VERSION:?}"
+
+          gh release edit "${RELEASE_TAG:?}" --tag "v${VERSION:?}" --draft=false --latest
+
+          git push origin --delete "refs/heads/${TEMP_BRANCH:?}" || true
+          if [ "$(git tag -l latest --merged HEAD)" = latest ]; then
+            git tag -f latest HEAD
+            git push -f origin refs/tags/latest
+          fi
+
+          echo "✅ Release v${VERSION:?} completed successfully!"
+          echo "🏷️ Target branch fast-forwarded and tag v${VERSION:?} pushed"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/justfile
+++ b/justfile
@@ -78,7 +78,7 @@ clean:
 
 # Run all CI checks locally
 ci: test lint audit fmt-check check-schema check
-    @echo "✓ All local CI checks passed"
+    @echo "✅ All local CI checks passed"
 
 # Generate code coverage
 coverage: (setup "coverage")
@@ -101,6 +101,10 @@ check-schema: (setup "schema")
 # Install binary and man pages
 install: (setup "build")
     cargo install --path . --locked
+
+# Build and publish new release
+release type="patch": (setup "cargo-edit")
+    gh workflow run -R pamburus/hl release.yml --ref $(git branch --show-current) --field release-type={{type}}
 
 # Bump version
 bump type="alpha": (setup "cargo-edit")


### PR DESCRIPTION
This pull request adds a `Release` GitHub workflow that fully automates the release process.

## Trigger

The workflow can be triggered:
- Manually on the GitHub Actions page
- By running `just release` command locally

## What it does

The workflow automatically:

1. **Generates release notes** from commit history and pull requests
2. **Bumps version** in relevant files (Cargo.toml, etc.)
3. **Builds cross-platform binaries** for all supported targets:
   - Linux (x86_64, aarch64) with glibc and musl
   - macOS (x86_64, aarch64)
   - Windows (x86_64, aarch64)
4. **Updates binary hashes** in `nix/binary-hashes.nix` for the Nix binary package
5. **Commits and pushes changes** back to the source branch
6. **Creates and publishes GitHub release** with attached binaries
7. **Updates `latest` tag** to point to the new release

## Benefits

- **Fully automated releases** - No manual steps required
- **Consistent process** - Eliminates human error in release workflow  
- **Immediate Nix support** - Binary package works as soon as release is published
- **Cross-platform binaries** - All supported platforms built simultaneously

## Files modified by automation

- `Cargo.toml` and `Cargo.lock` - Version bump
- `nix/binary-hashes.nix` - Updated with new binary hashes
- Git tags - Release tag and `latest` tag