### PR TITLE
chore(just): added `just changes`

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -53,7 +53,7 @@ body = """
 {%- if github -%}
     {%- set new_contributors = github.contributors | filter(attribute="is_first_time", value=true) %}
     {%- if new_contributors | length != 0 %}
-        ### New Contributors
+        ## New Contributors
         {% for contributor in new_contributors %}
             * @{{ contributor.username | replace(from="[bot]", to="") }} made their first contribution
                 {%- if contributor.pr_number %} in \


### PR DESCRIPTION
This pull request changes "New Contributors" section style to H2 to conform existing release notes style.
See #1069 for the previous similar fix.