### PR TITLE
build(release): added release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,10 +117,17 @@ jobs:
     needs: [prepare-release, build]
 
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.generate-token.outputs.token }}
           ref: ${{ needs.prepare-release.outputs.temp-branch }}
           fetch-depth: 0
 
@@ -170,13 +177,6 @@ jobs:
           # Create final tag pointing to commit with all changes
           git tag "v${VERSION:?}"
 
-      - name: Generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Fast-forward target branch and publish release
         run: |
           VERSION=${{ needs.prepare-release.outputs.version }}
@@ -185,8 +185,6 @@ jobs:
           TARGET_BRANCH=${{ github.ref_name }}
 
           git checkout -B "${TARGET_BRANCH:?}" "origin/${TARGET_BRANCH:?}"
-          git remote set-url origin https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/${{ github.repository }}.git
-
           git merge --ff-only "refs/heads/${TEMP_BRANCH:?}"
           git push origin "refs/heads/${TARGET_BRANCH:?}"
           git push origin "refs/tags/v${VERSION:?}"
@@ -201,3 +199,5 @@ jobs:
 
           echo "✅ Release v${VERSION:?} completed successfully!"
           echo "🏷️ Target branch fast-forwarded and tag v${VERSION:?} pushed"
+        env:
+          GH_TOKEN: ${{ guthub.token }}


### PR DESCRIPTION
This pull request modifies the last checkout action to use an application token. This allows changes to be pushed to the main branch, bypassing the ruleset restrictions.
The previous fix #1072 did not work as expected.
See original implementation in #1070.