### PR TITLE
feat: add --include-missing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,38 @@ See other [screenshots](https://github.com/pamburus/hl-extra/blob/c89a0726818eb6
 
     Displays only messages where the `span` field is an array with at least two elements, and the element at index 1 (i.e., the second element) is an object with a `name` field equal to `sp0001`.
 
+#### Handling missing fields in negative filters
+
+By default, negative filters (e.g., `field!=value`) only match records where the field exists and doesn't equal the value. Records missing the field are excluded from results.
+
+* Command
+
+    ```sh
+    hl example.log --include-missing -f 'status!=active'
+    ```
+
+    Displays messages where the `status` field either doesn't exist OR has a value other than `active`. Without `--include-missing`, only messages with a `status` field would be evaluated.
+
+* Command
+
+    ```sh
+    hl example.log --include-missing -q 'level = error and user.role != admin'
+    ```
+
+    Displays error-level messages where the `user.role` field is either missing or not equal to `admin`. This is useful for finding errors from non-admin users, including cases where the role isn't logged.
+
+* Use cases for `--include-missing`:
+  * Finding all records that don't match a specific value, including those where the field wasn't logged
+  * Debugging missing or optional fields in log messages
+  * Filtering by negative conditions when field presence varies across log sources
+
+* The flag can also be set via the environment variable:
+
+    ```sh
+    export HL_INCLUDE_MISSING=true
+    hl example.log -f 'error-code!=0'
+    ```
+
 ### Performing complex queries
 
 * Command
@@ -693,11 +725,12 @@ Options:
   -V, --version                          Print version
 
 Filtering Options:
-  -l, --level <LEVEL>    Filter messages by level [env: HL_LEVEL=]
-      --since <TIME>     Filter messages by timestamp >= <TIME> (--time-zone and --local options are honored)
-      --until <TIME>     Filter messages by timestamp <= <TIME> (--time-zone and --local options are honored)
-  -f, --filter <FILTER>  Filter messages by field values [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v'] where ~ does substring match and ~~ does regular expression match
-  -q, --query <QUERY>    Filter using query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc
+  -l, --level <LEVEL>       Filter messages by level [env: HL_LEVEL=]
+      --since <TIME>        Filter messages by timestamp >= <TIME> (--time-zone and --local options are honored)
+      --until <TIME>        Filter messages by timestamp <= <TIME> (--time-zone and --local options are honored)
+  -f, --filter <FILTER>     Filter messages by field values [k=v, k~=v, k~~=v, 'k!=v', 'k!~=v', 'k!~~=v'] where ~ does substring match and ~~ does regular expression match
+      --include-missing     Include records with missing fields in negative filter results [env: HL_INCLUDE_MISSING=] [default: false]
+  -q, --query <QUERY>       Filter using query, accepts expressions from --filter and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc
 
 Output Options:
       --color [<WHEN>]        Color output control [env: HL_COLOR=] [default: auto] [possible values: auto, always, never]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -183,7 +183,7 @@ fn test_filter_with_blank_lines() {
     let app = App::new(
         options().with_filter(
             Filter {
-                fields: FieldFilterSet::new(["msg=m2"]).unwrap(),
+                fields: FieldFilterSet::new(["msg=m2"], false).unwrap(),
                 ..Default::default()
             }
             .into(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,6 +172,19 @@ pub struct Opt {
     #[arg(short, long, num_args = 1, help_heading = heading::FILTERING)]
     pub filter: Vec<String>,
 
+    /// Include records with missing fields in negative filter results.
+    /// When enabled, a record without a field will match a negative filter (e.g., field!=value).
+    /// By default (disabled), only records with the field present are evaluated.
+    #[arg(
+        long,
+        env = "HL_INCLUDE_MISSING",
+        default_value_t = false,
+        overrides_with = "include_missing",
+        help_heading = heading::FILTERING,
+        action = ArgAction::Set
+    )]
+    pub include_missing: bool,
+
     /// Filter using query, accepts expressions from --filter
     /// and supports '(', ')', 'and', 'or', 'not', 'in', 'contain', 'like', '<', '>', '<=', '>=', etc.
     #[arg(short, long, num_args = 1, help_heading = heading::FILTERING)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn run() -> Result<()> {
     let time_format = LinuxDateFormat::new(&opt.time_format).compile();
     // Configure filter.
     let filter = hl::Filter {
-        fields: hl::FieldFilterSet::new(&opt.filter)?,
+        fields: hl::FieldFilterSet::new(&opt.filter, opt.include_missing)?,
         level: opt.level.map(|x| x.into()),
         since: if let Some(v) = &opt.since {
             Some(parse_time(v, &tz, &time_format)?.with_timezone(&Utc))
@@ -179,7 +179,7 @@ fn run() -> Result<()> {
 
     let mut query: Option<Query> = None;
     for q in &opt.query {
-        let right = Query::parse(q)?;
+        let right = Query::parse(q, opt.include_missing)?;
         if let Some(left) = query {
             query = Some(left.and(right));
         } else {

--- a/src/model/tests.rs
+++ b/src/model/tests.rs
@@ -201,7 +201,7 @@ fn test_raw_value_array() {
 
 #[test]
 fn test_field_filter_json_str_simple() {
-    let filter = FieldFilter::parse("mod=test").unwrap();
+    let filter = FieldFilter::parse("mod=test", false).unwrap();
     let record = parse(r#"{"mod":"test"}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":"test2"}"#);
@@ -212,7 +212,7 @@ fn test_field_filter_json_str_simple() {
 
 #[test]
 fn test_field_filter_json_str_empty() {
-    let filter = FieldFilter::parse("mod=").unwrap();
+    let filter = FieldFilter::parse("mod=", false).unwrap();
     let record = parse(r#"{"mod":""}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":"t"}"#);
@@ -223,7 +223,7 @@ fn test_field_filter_json_str_empty() {
 
 #[test]
 fn test_field_filter_json_str_quoted() {
-    let filter = FieldFilter::parse(r#"mod="test""#).unwrap();
+    let filter = FieldFilter::parse(r#"mod="test""#, false).unwrap();
     let record = parse(r#"{"mod":"test"}"#);
     assert!(!filter.apply(&record));
     let record = parse(r#"{"mod":"test2"}"#);
@@ -234,7 +234,7 @@ fn test_field_filter_json_str_quoted() {
 
 #[test]
 fn test_field_filter_json_str_escaped() {
-    let filter = FieldFilter::parse("mod=te st").unwrap();
+    let filter = FieldFilter::parse("mod=te st", false).unwrap();
     let record = parse(r#"{"mod":"te st"}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":"test"}"#);
@@ -245,7 +245,7 @@ fn test_field_filter_json_str_escaped() {
 
 #[test]
 fn test_field_filter_json_int() {
-    let filter = FieldFilter::parse("v=42").unwrap();
+    let filter = FieldFilter::parse("v=42", false).unwrap();
     let record = parse(r#"{"v":42}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"v":"42"}"#);
@@ -258,7 +258,7 @@ fn test_field_filter_json_int() {
 
 #[test]
 fn test_field_filter_json_int_escaped() {
-    let filter = FieldFilter::parse("v=42").unwrap();
+    let filter = FieldFilter::parse("v=42", false).unwrap();
     let record = parse(r#"{"v":42}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"v":"4\u0032"}"#);
@@ -267,7 +267,7 @@ fn test_field_filter_json_int_escaped() {
 
 #[test]
 fn test_field_filter_logfmt_str_simple() {
-    let filter = FieldFilter::parse("mod=test").unwrap();
+    let filter = FieldFilter::parse("mod=test", false).unwrap();
     let record = parse("mod=test");
     assert!(filter.apply(&record));
     let record = parse("mod=test2");
@@ -280,7 +280,7 @@ fn test_field_filter_logfmt_str_simple() {
 
 #[test]
 fn test_field_filter_logfmt_str_empty() {
-    let filter = FieldFilter::parse("mod=").unwrap();
+    let filter = FieldFilter::parse("mod=", false).unwrap();
     let record = parse(r#"mod="""#);
     assert!(filter.apply(&record));
     let record = parse("mod=t");
@@ -289,7 +289,7 @@ fn test_field_filter_logfmt_str_empty() {
 
 #[test]
 fn test_field_filter_logfmt_str_quoted() {
-    let filter = FieldFilter::parse(r#"mod="test""#).unwrap();
+    let filter = FieldFilter::parse(r#"mod="test""#, false).unwrap();
     let record = parse("mod=test");
     assert!(!filter.apply(&record));
     let record = parse(r#"mod=test2"#);
@@ -302,7 +302,7 @@ fn test_field_filter_logfmt_str_quoted() {
 
 #[test]
 fn test_field_filter_logfmt_str_escaped() {
-    let filter = FieldFilter::parse("mod=te st").unwrap();
+    let filter = FieldFilter::parse("mod=te st", false).unwrap();
     let record = parse(r#"mod="te st""#);
     assert!(filter.apply(&record));
     let record = parse(r#"mod=test"#);
@@ -313,7 +313,7 @@ fn test_field_filter_logfmt_str_escaped() {
 
 #[test]
 fn test_field_filter_logfmt_int() {
-    let filter = FieldFilter::parse("v=42").unwrap();
+    let filter = FieldFilter::parse("v=42", false).unwrap();
     let record = parse(r#"v=42"#);
     assert!(filter.apply(&record));
     let record = parse(r#"v="42""#);
@@ -326,7 +326,7 @@ fn test_field_filter_logfmt_int() {
 
 #[test]
 fn test_field_filter_logfmt_int_escaped() {
-    let filter = FieldFilter::parse("v=42").unwrap();
+    let filter = FieldFilter::parse("v=42", false).unwrap();
     let record = parse(r#"v=42"#);
     assert!(filter.apply(&record));
     let record = parse(r#"v="4\u0032""#);
@@ -409,7 +409,7 @@ fn test_record_filter_until() {
 #[test]
 fn test_record_filter_fields() {
     let filter = Filter {
-        fields: FieldFilterSet::new(["mod=test", "v=42"]).unwrap(),
+        fields: FieldFilterSet::new(["mod=test", "v=42"], false).unwrap(),
         ..Default::default()
     };
     let record = parse(r#"{"mod":"test","v":42}"#);
@@ -426,7 +426,7 @@ fn test_record_filter_all() {
         level: Some(Level::Error),
         since: Some(Utc.with_ymd_and_hms(2021, 1, 1, 0, 0, 0).unwrap()),
         until: Some(Utc.with_ymd_and_hms(2021, 1, 2, 0, 0, 0).unwrap()),
-        fields: FieldFilterSet::new(["mod=test", "v=42"]).unwrap(),
+        fields: FieldFilterSet::new(["mod=test", "v=42"], false).unwrap(),
     };
     let record = parse(r#"{"level":"error","ts":"2021-01-01T00:00:00Z","mod":"test","v":42}"#);
     assert!(filter.apply(&record));
@@ -440,9 +440,9 @@ fn test_record_filter_all() {
 
 #[test]
 fn test_record_filter_or() {
-    let filter = FieldFilter::parse("mod=test")
+    let filter = FieldFilter::parse("mod=test", false)
         .unwrap()
-        .or(FieldFilter::parse("v=42").unwrap());
+        .or(FieldFilter::parse("v=42", false).unwrap());
     let record = parse(r#"{"mod":"test","v":42}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":"test","v":43}"#);
@@ -455,9 +455,9 @@ fn test_record_filter_or() {
 
 #[test]
 fn test_record_filter_and() {
-    let filter = FieldFilter::parse("mod=test")
+    let filter = FieldFilter::parse("mod=test", false)
         .unwrap()
-        .and(FieldFilter::parse("v=42").unwrap());
+        .and(FieldFilter::parse("v=42", false).unwrap());
     let record = parse(r#"{"mod":"test","v":42}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":"test","v":43}"#);
@@ -470,7 +470,7 @@ fn test_record_filter_and() {
 
 #[test]
 fn test_field_filter_key_match() {
-    let filter = FieldFilter::parse("mod.test=42").unwrap();
+    let filter = FieldFilter::parse("mod.test=42", false).unwrap();
     let record = parse(r#"{"mod.test":42}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":{"test":42}}"#);
@@ -483,7 +483,7 @@ fn test_field_filter_key_match() {
 
 #[test]
 fn test_field_filter_key_match_partial() {
-    let filter = FieldFilter::parse("mod.test=42").unwrap();
+    let filter = FieldFilter::parse("mod.test=42", false).unwrap();
     let record = parse(r#"{"mod.test":42}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod.test2":42}"#);
@@ -494,7 +494,7 @@ fn test_field_filter_key_match_partial() {
     assert!(!filter.apply(&record));
     let record = parse(r#"{"mod":{"test":42,"test2":42}}"#);
     assert!(filter.apply(&record));
-    let filter = FieldFilter::parse("mod.test.inner=42").unwrap();
+    let filter = FieldFilter::parse("mod.test.inner=42", false).unwrap();
     let record = parse(r#"{"mod":{"test":{"inner":42}}}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod.test":{"inner":42}}"#);
@@ -505,7 +505,7 @@ fn test_field_filter_key_match_partial() {
 
 #[test]
 fn test_field_filter_key_match_partial_nested() {
-    let filter = FieldFilter::parse("mod.test=42").unwrap();
+    let filter = FieldFilter::parse("mod.test=42", false).unwrap();
     let record = parse(r#"{"mod":{"test":42}}"#);
     assert!(filter.apply(&record));
     let record = parse(r#"{"mod":{"test2":42}}"#);
@@ -518,7 +518,7 @@ fn test_field_filter_key_match_partial_nested() {
 
 #[test]
 fn test_field_filter_caller() {
-    let filter = FieldFilter::parse("caller~=somesource.py").unwrap();
+    let filter = FieldFilter::parse("caller~=somesource.py", false).unwrap();
     let record = parse(r#"caller=somesource.py:42"#);
     assert!(filter.apply(&record));
     let record = parse(r#"caller=somesource.go:42"#);
@@ -527,20 +527,20 @@ fn test_field_filter_caller() {
 
 #[test]
 fn test_field_filter_array() {
-    let any = FieldFilter::parse("span.[].name=a").unwrap();
-    let first = FieldFilter::parse("span.[0].name=b").unwrap();
+    let any = FieldFilter::parse("span.[].name=a", false).unwrap();
+    let first = FieldFilter::parse("span.[0].name=b", false).unwrap();
 
     let record = parse(r#"{"span":[{"name":"a"},{"name":"b"}]}"#);
     assert!(any.apply(&record));
     assert!(!first.apply(&record));
 
-    let inv = FieldFilter::parse("span.[0a].name=a").unwrap();
+    let inv = FieldFilter::parse("span.[0a].name=a", false).unwrap();
     assert!(!inv.apply(&record));
 
-    let inv = FieldFilter::parse("span.[0]x=a").unwrap();
+    let inv = FieldFilter::parse("span.[0]x=a", false).unwrap();
     assert!(!inv.apply(&record));
 
-    let inv = FieldFilter::parse("span.[0.name=a").unwrap();
+    let inv = FieldFilter::parse("span.[0.name=a", false).unwrap();
     assert!(!inv.apply(&record));
 
     let record = parse(r#"{"span":[{"name":"b"},{"name":"c"}]}"#);
@@ -555,27 +555,27 @@ fn test_field_filter_array() {
     assert!(!any.apply(&record));
     assert!(!first.apply(&record));
 
-    let inv = FieldFilter::parse("span.[0=b").unwrap();
+    let inv = FieldFilter::parse("span.[0=b", false).unwrap();
     assert!(!inv.apply(&record));
 
     let record = parse(r#"{"span":10}"#);
     assert!(!any.apply(&record));
     assert!(!first.apply(&record));
 
-    let any = FieldFilter::parse("span.[]=a").unwrap();
-    let first = FieldFilter::parse("span.[0]=b").unwrap();
+    let any = FieldFilter::parse("span.[]=a", false).unwrap();
+    let first = FieldFilter::parse("span.[0]=b", false).unwrap();
 
     let record = parse(r#"{"span":["a","b"]}"#);
     assert!(any.apply(&record));
     assert!(!first.apply(&record));
 
-    let inv = FieldFilter::parse("span.[0=b").unwrap();
+    let inv = FieldFilter::parse("span.[0=b", false).unwrap();
     assert!(!inv.apply(&record));
 
-    let inv = FieldFilter::parse("span.x=b").unwrap();
+    let inv = FieldFilter::parse("span.x=b", false).unwrap();
     assert!(!inv.apply(&record));
 
-    let inv = FieldFilter::parse("span.[98172389172389172312983761823]=b").unwrap();
+    let inv = FieldFilter::parse("span.[98172389172389172312983761823]=b", false).unwrap();
     assert!(!inv.apply(&record));
 }
 
@@ -756,7 +756,7 @@ fn test_logfmt_string(#[case] input: &[u8], #[case] expected: RawValue) {
 #[case(r#"msg="Synced""#, "msg=Synced", true)] // 2
 #[case(r#"msg="Not synced""#, "msg=Not synced", true)] // 3
 fn test_logfmt_string_filter(#[case] input: &str, #[case] filter: &str, #[case] expected: bool) {
-    let filter = FieldFilter::parse(filter).unwrap();
+    let filter = FieldFilter::parse(filter, false).unwrap();
     let record = parse(input);
     assert_eq!(filter.apply(&record), expected);
 }
@@ -771,4 +771,176 @@ fn try_parse(s: &str) -> Result<Record<'_>> {
     let raw = items.into_iter().next().unwrap()?.record;
     let parser = Parser::new(ParserSettings::default());
     Ok(parser.parse(&raw))
+}
+
+#[test]
+fn test_field_filter_negative_missing_field() {
+    let filter = FieldFilter::parse("log.target!=foo", true).unwrap();
+
+    let record = parse(r#"log.target=foo"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"log.target=bar"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"target=bar"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"message=test"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_negative_nested_missing() {
+    let filter = FieldFilter::parse("a.b.c!=value", true).unwrap();
+
+    let record = parse(r#"{"a":{"b":{"c":"value"}}}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"a":{"b":{"c":"other"}}}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"a":{"b":{}}}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"a":{}}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"x":"y"}"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_negative_predefined_fields() {
+    let filter = FieldFilter::parse("message!=test", true).unwrap();
+
+    let record = parse(r#"{"msg":"test"}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"msg":"other"}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"level":"info"}"#);
+    assert!(filter.apply(&record));
+
+    let filter = FieldFilter::parse("logger!=mylogger", true).unwrap();
+    let record = parse(r#"{"logger":"mylogger"}"#);
+    assert!(!filter.apply(&record));
+    let record = parse(r#"{"logger":"other"}"#);
+    assert!(filter.apply(&record));
+    let record = parse(r#"{"level":"info"}"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_positive_missing_field() {
+    let filter = FieldFilter::parse("log.target=foo", false).unwrap();
+
+    let record = parse(r#"{"log.target":"foo"}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"log.target":"bar"}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"target":"bar"}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"message":"test"}"#);
+    assert!(!filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_array_iteration_with_negation() {
+    let filter = FieldFilter::parse("span.[].name!=target", false).unwrap();
+
+    let record = parse(r#"{"span":[{"name":"target"},{"name":"other"}]}"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_array_exact_index_with_result() {
+    let filter = FieldFilter::parse("span.[1].name=target", false).unwrap();
+
+    let record = parse(r#"{"span":[{"name":"other"},{"name":"target"}]}"#);
+    assert!(filter.apply(&record));
+
+    let filter2 = FieldFilter::parse("span.[1].name=target", false).unwrap();
+    let record2 = parse(r#"{"span":[{"name":"other"},{"name":"different"}]}"#);
+    assert!(!filter2.apply(&record2));
+}
+
+#[test]
+fn test_field_filter_array_nested_path_with_tail() {
+    let filter = FieldFilter::parse("data.[].span.name=test", false).unwrap();
+
+    let record = parse(r#"{"data":[{"span":{"name":"test"}}]}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"data":[{"span":{"name":"other"}},{"span":{"name":"test"}}]}"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_array_nested_path_no_field() {
+    let filter = FieldFilter::parse("data.[].span.name=test", false).unwrap();
+
+    let record = parse(r#"{"data":[{"other":"value"},{"different":"value"}]}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"data":[{"span":{"other":"value"}}]}"#);
+    assert!(!filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_array_exact_index_nested_path() {
+    let filter = FieldFilter::parse("data.[0].span.name=test", false).unwrap();
+
+    let record = parse(r#"{"data":[{"span":{"name":"test"}}]}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"data":[{"span":{"name":"other"}}]}"#);
+    assert!(!filter.apply(&record));
+
+    let filter_neg = FieldFilter::parse("data.[1].span.name!=test", false).unwrap();
+    let record = parse(r#"{"data":[{"span":{"name":"first"}},{"span":{"name":"other"}}]}"#);
+    assert!(filter_neg.apply(&record));
+}
+
+#[test]
+fn test_field_filter_negative_timestamp_missing() {
+    let filter = FieldFilter::parse("ts!=2021-01-01", true).unwrap();
+
+    let record = parse(r#"{"ts":"2021-01-01"}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"ts":"2021-01-02"}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"level":"info"}"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_negative_caller_missing() {
+    let filter = FieldFilter::parse("caller!=main.go:42", true).unwrap();
+
+    let record = parse(r#"{"caller":"main.go:42"}"#);
+    assert!(!filter.apply(&record));
+
+    let record = parse(r#"{"caller":"other.go:10"}"#);
+    assert!(filter.apply(&record));
+
+    let record = parse(r#"{"level":"info"}"#);
+    assert!(filter.apply(&record));
+}
+
+#[test]
+fn test_field_filter_array_exact_index_false_result() {
+    let filter = FieldFilter::parse("items.[2]=value", false).unwrap();
+
+    let record = parse(r#"{"items":["a","b","different"]}"#);
+    assert!(!filter.apply(&record));
+
+    let filter_neg = FieldFilter::parse("items.[2]!=value", false).unwrap();
+    assert!(filter_neg.apply(&record));
 }

--- a/src/query/tests.rs
+++ b/src/query/tests.rs
@@ -54,8 +54,10 @@ fn test_and_or() {
 #[test]
 fn test_query_or() {
     let queries = [
-        Query::parse(".a=1").unwrap().or(Query::parse(".b=2").unwrap()),
-        Query::parse(".a=1 or .b=2").unwrap(),
+        Query::parse(".a=1", false)
+            .unwrap()
+            .or(Query::parse(".b=2", false).unwrap()),
+        Query::parse(".a=1 or .b=2", false).unwrap(),
     ];
 
     for query in &queries {
@@ -71,8 +73,10 @@ fn test_query_or() {
 #[test]
 fn test_query_and() {
     let queries = [
-        Query::parse(".a=1").unwrap().and(Query::parse(".b=2").unwrap()),
-        Query::parse(".a=1 and .b=2").unwrap(),
+        Query::parse(".a=1", false)
+            .unwrap()
+            .and(Query::parse(".b=2", false).unwrap()),
+        Query::parse(".a=1 and .b=2", false).unwrap(),
     ];
 
     for query in &queries {
@@ -87,7 +91,10 @@ fn test_query_and() {
 
 #[test]
 fn test_query_not() {
-    let queries = [!Query::parse(".a=1").unwrap(), Query::parse("not .a=1").unwrap()];
+    let queries = [
+        !Query::parse(".a=1", false).unwrap(),
+        Query::parse("not .a=1", false).unwrap(),
+    ];
 
     for query in &queries {
         let record = parse(r#"{"a":1}"#);
@@ -99,8 +106,8 @@ fn test_query_not() {
 
 #[test]
 fn test_query_bitwise_operators() {
-    let q1 = Query::parse(".a=1").unwrap();
-    let q2 = Query::parse(".b=2").unwrap();
+    let q1 = Query::parse(".a=1", false).unwrap();
+    let q2 = Query::parse(".b=2", false).unwrap();
 
     // Test BitAnd (&)
     let and_query1 = q1.clone() & q2.clone();
@@ -136,7 +143,7 @@ fn test_query_bitwise_operators() {
 
 #[test]
 fn test_query_level() {
-    let query = Query::parse("level=info").unwrap();
+    let query = Query::parse("level=info", false).unwrap();
     let record = parse(r#"{"level":"info"}"#);
     assert!(record.matches(&query));
     let record = parse(r#"{"level":"error"}"#);
@@ -146,7 +153,7 @@ fn test_query_level() {
 #[test]
 fn test_query_json_str_simple() {
     for q in &["mod=test", r#"mod="test""#] {
-        let query = Query::parse(q).unwrap();
+        let query = Query::parse(q, false).unwrap();
         let record = parse(r#"{"mod":"test"}"#);
         assert!(record.matches(&query));
         let record = parse(r#"{"mod":"test2"}"#);
@@ -158,7 +165,7 @@ fn test_query_json_str_simple() {
 
 #[test]
 fn test_query_json_str_empty() {
-    let query = Query::parse(r#"mod="""#).unwrap();
+    let query = Query::parse(r#"mod="""#, false).unwrap();
     let record = parse(r#"{"mod":""}"#);
     assert!(record.matches(&query));
     let record = parse(r#"{"mod":"t"}"#);
@@ -169,7 +176,7 @@ fn test_query_json_str_empty() {
 
 #[test]
 fn test_query_json_str_quoted() {
-    let query = Query::parse(r#"mod="\"test\"""#).unwrap();
+    let query = Query::parse(r#"mod="\"test\"""#, false).unwrap();
     let record = parse(r#"{"mod":"test"}"#);
     assert!(!record.matches(&query));
     let record = parse(r#"{"mod":"test2"}"#);
@@ -180,7 +187,7 @@ fn test_query_json_str_quoted() {
 
 #[test]
 fn test_query_json_int() {
-    let query = Query::parse("some-value=1447015572184281088").unwrap();
+    let query = Query::parse("some-value=1447015572184281088", false).unwrap();
     let record = parse(r#"{"some-value":1447015572184281088}"#);
     assert!(record.matches(&query));
     let record = parse(r#"{"some-value":1447015572184281089}"#);
@@ -191,7 +198,7 @@ fn test_query_json_int() {
 
 #[test]
 fn test_query_json_int_escaped() {
-    let query = Query::parse("v=42").unwrap();
+    let query = Query::parse("v=42", false).unwrap();
     let record = parse(r#"{"v":42}"#);
     assert!(record.matches(&query));
     let record = parse(r#"{"v":"4\u0032"}"#);
@@ -200,7 +207,7 @@ fn test_query_json_int_escaped() {
 
 #[test]
 fn test_query_json_float() {
-    let query = Query::parse("v > 0.5").unwrap();
+    let query = Query::parse("v > 0.5", false).unwrap();
     let record = parse(r#"{"v":0.4}"#);
     assert!(!record.matches(&query));
     let record = parse(r#"{"v":0.5}"#);
@@ -217,7 +224,7 @@ fn test_query_json_float() {
 
 #[test]
 fn test_query_json_in_str() {
-    let query = Query::parse("v in (a,b,c)").unwrap();
+    let query = Query::parse("v in (a,b,c)", false).unwrap();
     let record = parse(r#"{"v":"a"}"#);
     assert!(record.matches(&query));
     let record = parse(r#"{"v":"b"}"#);
@@ -232,7 +239,7 @@ fn test_query_json_in_str() {
 
 #[test]
 fn test_query_json_in_int() {
-    let query = Query::parse("v in (1,2)").unwrap();
+    let query = Query::parse("v in (1,2)", false).unwrap();
     let record = parse(r#"{"v":1}"#);
     assert!(record.matches(&query));
     let record = parse(r#"{"v":"1"}"#);
@@ -249,7 +256,7 @@ fn test_query_json_in_int() {
 
 #[test]
 fn query_in_set_file_valid() {
-    let query = Query::parse("v in @src/testing/assets/query/set-valid").unwrap();
+    let query = Query::parse("v in @src/testing/assets/query/set-valid", false).unwrap();
     let record = parse(r#"{"v":"line"}"#);
     assert!(!record.matches(&query));
     let record = parse(r#"{"v":"line1"}"#);
@@ -265,7 +272,7 @@ fn query_in_set_file_valid() {
 #[test]
 fn query_in_set_file_invalid() {
     let filename = "src/testing/assets/query/set-invalid";
-    let result = Query::parse(format!("v in @{}", filename));
+    let result = Query::parse(format!("v in @{}", filename), false);
     assert!(result.is_err());
     let err = result.err().unwrap();
     if let Error::FailedToLoadFile { path, source } = &err {
@@ -284,7 +291,7 @@ fn query_in_set_file_invalid() {
 #[test]
 fn query_in_set_file_not_found() {
     let filename = "src/testing/assets/query/set-not-found";
-    let result = Query::parse(format!("v in @{}", filename));
+    let result = Query::parse(format!("v in @{}", filename), false);
     assert!(result.is_err());
     let err = result.err().unwrap();
     if let Error::FailedToReadFile { path, source } = &err {
@@ -299,4 +306,190 @@ fn parse(s: &str) -> Record<'_> {
     let raw = RawRecord::parser().parse(s.as_bytes()).next().unwrap().unwrap().record;
     let parser = RecordParser::new(ParserSettings::default());
     parser.parse(&raw)
+}
+
+#[test]
+fn test_query_include_missing_not_equal() {
+    let query_without = Query::parse("age != 30", false).unwrap();
+    let query_with = Query::parse("age != 30", true).unwrap();
+
+    assert!(!parse(r#"{"age":30}"#).matches(&query_without));
+    assert!(!parse(r#"{"age":30}"#).matches(&query_with));
+
+    assert!(parse(r#"{"age":25}"#).matches(&query_without));
+    assert!(parse(r#"{"age":25}"#).matches(&query_with));
+
+    assert!(!parse(r#"{"name":"bob"}"#).matches(&query_without));
+    assert!(parse(r#"{"name":"bob"}"#).matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_not_in() {
+    let query_without = Query::parse("status not in (active, pending)", false).unwrap();
+    let query_with = Query::parse("status not in (active, pending)", true).unwrap();
+
+    let record = parse(r#"{"status":"active"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(!record.matches(&query_with));
+
+    let record = parse(r#"{"status":"completed"}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"name":"test"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_not_like() {
+    let query_without = Query::parse("name not like test*", false).unwrap();
+    let query_with = Query::parse("name not like test*", true).unwrap();
+
+    let record = parse(r#"{"name":"test123"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(!record.matches(&query_with));
+
+    let record = parse(r#"{"name":"prod123"}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"id":42}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_not_contain() {
+    let query_without = Query::parse("msg not contain error", false).unwrap();
+    let query_with = Query::parse("msg not contain error", true).unwrap();
+
+    assert!(!parse(r#"{"msg":"an error occurred"}"#).matches(&query_without));
+    assert!(!parse(r#"{"msg":"an error occurred"}"#).matches(&query_with));
+
+    assert!(parse(r#"{"msg":"success"}"#).matches(&query_without));
+    assert!(parse(r#"{"msg":"success"}"#).matches(&query_with));
+
+    assert!(!parse(r#"{"status":"ok"}"#).matches(&query_without));
+    assert!(parse(r#"{"status":"ok"}"#).matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_not_regex() {
+    let query_without = Query::parse(r#"code !~~= "^ERR""#, false).unwrap();
+    let query_with = Query::parse(r#"code !~~= "^ERR""#, true).unwrap();
+
+    assert!(!parse(r#"{"code":"ERR123"}"#).matches(&query_without));
+    assert!(!parse(r#"{"code":"ERR123"}"#).matches(&query_with));
+
+    assert!(parse(r#"{"code":"OK123"}"#).matches(&query_without));
+    assert!(parse(r#"{"code":"OK123"}"#).matches(&query_with));
+
+    assert!(!parse(r#"{"msg":"test"}"#).matches(&query_without));
+    assert!(parse(r#"{"msg":"test"}"#).matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_numeric_not_equal() {
+    let query_without = Query::parse("count != 10", false).unwrap();
+    let query_with = Query::parse("count != 10", true).unwrap();
+
+    let record = parse(r#"{"count":10}"#);
+    assert!(!record.matches(&query_without));
+    assert!(!record.matches(&query_with));
+
+    let record = parse(r#"{"count":5}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"name":"test"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_numeric_not_in() {
+    let query_without = Query::parse("port not in (80, 443, 8080)", false).unwrap();
+    let query_with = Query::parse("port not in (80, 443, 8080)", true).unwrap();
+
+    let record = parse(r#"{"port":80}"#);
+    assert!(!record.matches(&query_without));
+    assert!(!record.matches(&query_with));
+
+    let record = parse(r#"{"port":3000}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"host":"localhost"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_compound_and() {
+    let query_without = Query::parse("age != 30 and city != NYC", false).unwrap();
+    let query_with = Query::parse("age != 30 and city != NYC", true).unwrap();
+
+    let record = parse(r#"{"age":25,"city":"LA"}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"age":30,"city":"LA"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(!record.matches(&query_with));
+
+    let record = parse(r#"{"city":"LA"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"age":25}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"name":"test"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_compound_or() {
+    let query_without = Query::parse("age != 30 or status != active", false).unwrap();
+    let query_with = Query::parse("age != 30 or status != active", true).unwrap();
+
+    let record = parse(r#"{"age":25,"status":"inactive"}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"age":25,"status":"active"}"#);
+    assert!(record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"age":30,"status":"active"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(!record.matches(&query_with));
+
+    let record = parse(r#"{"status":"active"}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+
+    let record = parse(r#"{"age":30}"#);
+    assert!(!record.matches(&query_without));
+    assert!(record.matches(&query_with));
+}
+
+#[test]
+fn test_query_include_missing_positive_operators_unaffected() {
+    let query_equal_without = Query::parse("age = 30", false).unwrap();
+    let query_equal_with = Query::parse("age = 30", true).unwrap();
+
+    let record = parse(r#"{"name":"test"}"#);
+    assert!(!record.matches(&query_equal_without));
+    assert!(!record.matches(&query_equal_with));
+
+    let query_in_without = Query::parse("status in (active, pending)", false).unwrap();
+    let query_in_with = Query::parse("status in (active, pending)", true).unwrap();
+
+    let record = parse(r#"{"name":"test"}"#);
+    assert!(!record.matches(&query_in_without));
+    assert!(!record.matches(&query_in_with));
 }


### PR DESCRIPTION
Add new --include-missing CLI flag to control whether records with missing fields match negative filters (e.g., field!=value).

When disabled (default behavior):
- Only records with the field present are evaluated against the filter
- Records missing the field are excluded from results

When enabled:
- Records without a field will match negative filters like field!=value
- Example: A record without "log.target" will match "log.target!=foo"