### PR TITLE
fix(query): add alias `msg` for `message`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,7 +1087,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.32.3-alpha.3"
+version = "0.32.3-alpha.4"
 dependencies = [
  "assert_matches",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.32.3-alpha.3"
+version = "0.32.3-alpha.4"
 edition = "2024"
 license = "MIT"
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -19,7 +19,6 @@ use crate::model::{
     FieldFilter, FieldFilterKey, Level, Number, NumericOp, Record, RecordFilter, RecordFilterNone, UnaryBoolOp,
     ValueMatchPolicy,
 };
-use crate::types::FieldKind;
 
 // ---
 
@@ -308,12 +307,7 @@ fn parse_field_name(pair: Pair<Rule>) -> Result<FieldFilterKey<String>> {
     let inner = pair.into_inner().next().unwrap();
     Ok(match inner.as_rule() {
         Rule::json_string => FieldFilterKey::Custom(json::from_str(inner.as_str())?),
-        _ => match inner.as_str() {
-            "message" => FieldFilterKey::Predefined(FieldKind::Message),
-            "logger" => FieldFilterKey::Predefined(FieldKind::Logger),
-            "caller" => FieldFilterKey::Predefined(FieldKind::Caller),
-            _ => FieldFilterKey::Custom(inner.as_str().trim_start_matches('.').to_owned()),
-        },
+        _ => FieldFilterKey::parse(inner.as_str())?.to_owned(),
     })
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -262,7 +262,7 @@ pub struct MessageField(pub Field);
 
 impl Default for MessageField {
     fn default() -> Self {
-        Self(Field::new(vec!["msg".into()]))
+        Self(Field::new(vec!["msg".into(), "message".into()]))
     }
 }
 


### PR DESCRIPTION
This adds alias `msg` for predefined field `message` in `--query` to maintain consistency with `--filter`.