### PR TITLE
fix: preserve nested objects when no predefined fields match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.33.1-alpha.3"
+version = "0.33.1-alpha.4"
 dependencies = [
  "anstream",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.33.1-alpha.3"
+version = "0.33.1-alpha.4"
 edition = "2024"
 license = "MIT"
 


### PR DESCRIPTION
The previous fix in #1179 excluded container objects even when none of their nested fields matched a predefined field configuration. Now containers are only excluded when at least one nested predefined field is actually
matched.

Additional fix for #176.