### PR TITLE
fix: hide empty nested objects with `-e` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.33.1-alpha.8"
+version = "0.33.1-alpha.9"
 dependencies = [
  "anstream",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.33.1-alpha.8"
+version = "0.33.1-alpha.9"
 edition = "2024"
 license = "MIT"
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -27,7 +27,7 @@ pub use themecfg::{Element, ThemeInfo, ThemeOrigin};
 
 pub trait StylingPush<B: Push<u8>> {
     fn element<R, F: FnOnce(&mut Self) -> R>(&mut self, element: Element, f: F) -> R;
-    fn batch<F: FnOnce(&mut B)>(&mut self, f: F);
+    fn batch<R, F: FnOnce(&mut B) -> R>(&mut self, f: F) -> R;
     fn space(&mut self);
     fn reset(&mut self);
 }
@@ -261,7 +261,7 @@ impl<'a, B: Push<u8>> StylingPush<B> for Styler<'a, B> {
     }
 
     #[inline]
-    fn batch<F: FnOnce(&mut B)>(&mut self, f: F) {
+    fn batch<R, F: FnOnce(&mut B) -> R>(&mut self, f: F) -> R {
         self.sync();
         f(self.buf)
     }


### PR DESCRIPTION
Apply `hide_empty_fields` recursively to nested object fields and hide objects that become empty after filtering. Use single-pass approach with buffer rollback to avoid double-parsing.

- Hide empty nested fields when flattening (default behavior)
- Hide empty objects and objects with all empty fields
- Show ellipsis (`...`) indicator when fields are hidden
- Efficient single-pass implementation with buffer rollback