### PR TITLE
fix(formatting): do not hide siblings of nested predefined fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.33.1-alpha.9"
+version = "0.33.1-alpha.10"
 dependencies = [
  "anstream",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 repository = "https://github.com/pamburus/hl"
 authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-version = "0.33.1-alpha.9"
+version = "0.33.1-alpha.10"
 edition = "2024"
 license = "MIT"
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -412,7 +412,7 @@ fn test_issue_176_simple_span_logfmt() {
 #[test]
 fn test_issue_176_complex_span_json() {
     let input = input(concat!(
-        r#"{"message":"test","span":{"name":"main","source":"main.rs:12","extra":"ignored"}}"#,
+        r#"{"message":"test","span":{"name":"main","source":"main.rs:12","extra":"included"}}"#,
         "\n",
     ));
     let mut output = Vec::new();
@@ -438,7 +438,10 @@ fn test_issue_176_complex_span_json() {
         }),
     );
     app.run(vec![input], &mut output).unwrap();
-    assert_eq!(std::str::from_utf8(&output).unwrap(), "main: test @ main.rs:12\n");
+    assert_eq!(
+        std::str::from_utf8(&output).unwrap(),
+        "main: test span={ extra=included } @ main.rs:12\n"
+    );
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,5 +61,6 @@ pub use console::enable_ansi_support;
 
 // public type aliases
 pub type IncludeExcludeKeyFilter = filtering::IncludeExcludeKeyFilter<DefaultNormalizing>;
+pub type ExactIncludeExcludeKeyFilter = filtering::IncludeExcludeKeyFilter<filtering::NoNormalizing>;
 pub type KeyMatchOptions = filtering::MatchOptions<DefaultNormalizing>;
 pub type QueryNone = model::RecordFilterNone;

--- a/src/model.rs
+++ b/src/model.rs
@@ -855,10 +855,9 @@ impl FieldSettings {
                 RawValue::Object(value) => {
                     let mut object = Object::default();
                     if value.parse_into(&mut object).is_ok() {
-                        ps.blocks[nested].apply_each_ctx(ps, object.fields.iter(), to, ctx, false)
-                    } else {
-                        false
+                        ps.blocks[nested].apply_each_ctx(ps, object.fields.iter(), to, ctx, false);
                     }
+                    false
                 }
                 _ => false,
             },

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -154,6 +154,25 @@ pub struct PredefinedFields {
     pub caller_line: CallerLineField,
 }
 
+impl PredefinedFields {
+    pub fn nested_field_names(&self) -> impl Iterator<Item = &str> {
+        let fields: [&[String]; 7] = [
+            &self.time.0.names,
+            &self.message.0.names,
+            &self.logger.0.names,
+            &self.caller.0.names,
+            &self.caller_file.0.names,
+            &self.caller_line.0.names,
+            self.level.variants.first().map(|v| v.names.as_slice()).unwrap_or(&[]),
+        ];
+        fields
+            .into_iter()
+            .flatten()
+            .filter(|name| name.contains('.'))
+            .map(|s| s.as_str())
+    }
+}
+
 impl Default for &PredefinedFields {
     fn default() -> Self {
         static DEFAULT: Lazy<PredefinedFields> = Lazy::new(PredefinedFields::default);


### PR DESCRIPTION
When a predefined field is configured with a nested path (e.g., `span.name`), the nested field should be hidden from regular fields output without triggering the `...` hidden fields indicator. However, the sibling fields (e.g., `span.context`) should not be hidden.

Changes:
- Add `nested_field_names()` method to `PredefinedFields` to iterate over  nested predefined field paths
- Build a separate `IncludeExcludeKeyFilter` for predefined nested fields
- Add `FormatResult` enum to distinguish between formatted, hidden by user (shows `...`), and hidden by predefined (silent skip)
- Pass predefined filter to formatter and check it before user filter
- Roll back empty objects that become empty due to predefined filtering

Additional fix for #176