### PR TITLE
fix: support for numbers in scientific notation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.34.0"
+version = "0.34.1-alpha.1"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.34.0"
+version = "0.34.1-alpha.1"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -928,7 +928,7 @@ pub mod string {
                             | [b't', b'r', b'u', b'e']
                             | [b'f', b'a', b'l', b's', b'e']
                             | [b'n', b'u', b'l', b'l']
-                    )
+                    ) && !looks_like_number(&buf[begin..])
                 }
             } else {
                 false

--- a/src/model.rs
+++ b/src/model.rs
@@ -1300,7 +1300,7 @@ impl FromStr for Number {
 
     #[inline]
     fn from_str(s: &str) -> Result<Self> {
-        if s.contains('.') {
+        if s.contains('.') || s.contains('e') || s.contains('E') {
             Ok(Self::Float(s.parse().map_err(Error::from)?))
         } else {
             Ok(Self::Integer(s.parse().map_err(Error::from)?))

--- a/src/number/tests.rs
+++ b/src/number/tests.rs
@@ -2,16 +2,28 @@ use super::*;
 use rstest::rstest;
 
 #[rstest]
-#[case(b"", false)] // 1
-#[case(b"0", true)] // 2
-#[case(b"+1", true)] // 3
-#[case(b"-1", true)] // 4
-#[case(b"1.1", true)] // 5
-#[case(b"1.1.0", false)] // 6
-#[case(b"a=1", false)] // 7
-#[case(b"3.787e+04", true)] // 8
-#[case(b"3.787e-04", true)] // 9
-#[case(b"-3.787e-04", true)] // 10
+#[case::empty(b"", false)]
+#[case::zero(b"0", true)]
+#[case::positive_integer(b"+1", true)]
+#[case::negative_integer(b"-1", true)]
+#[case::decimal(b"1.1", true)]
+#[case::invalid_double_dot(b"1.1.0", false)]
+#[case::invalid_with_equals(b"a=1", false)]
+#[case::scientific_positive_exponent(b"3.787e+04", true)]
+#[case::scientific_negative_exponent(b"3.787e-04", true)]
+#[case::scientific_negative_base_negative_exponent(b"-3.787e-04", true)]
+#[case::scientific_no_decimal(b"1e10", true)]
+#[case::scientific_uppercase_e(b"1E10", true)]
+#[case::scientific_negative_base(b"-1e10", true)]
+#[case::scientific_small_exponent(b"1e-10", true)]
+#[case::scientific_explicit_plus(b"1e+10", true)]
+#[case::scientific_zero(b"0e0", true)]
+#[case::scientific_large_exponent(b"123e456", true)]
+#[case::scientific_with_decimal(b"1.0e0", true)]
+#[case::invalid_missing_exponent(b"1e", false)]
+#[case::invalid_missing_base(b"e10", false)]
+#[case::invalid_double_e(b"1ee10", false)]
+#[case::invalid_decimal_in_exponent(b"1e10.5", false)]
 fn test_looks_like_number(#[case] input: &[u8], #[case] expected: bool) {
     assert_eq!(looks_like_number(input), expected);
 }

--- a/src/query.pest
+++ b/src/query.pest
@@ -31,7 +31,7 @@ _or  = _{ ^"or" ~ &punctuation | "||" }
 _and = _{ ^"and" ~ &punctuation | "&&" }
 _not = _{ ^"not" ~ &punctuation | "!" }
 
-_ff_num_op_1       = _{ op_le | op_ge | op_lt | op_gt }
+_ff_num_op_1       = _{ op_le | op_ge | op_lt | op_gt | op_equal | op_not_equal }
 _ff_num_op_n       = _{ op_in | op_not_in }
 _ff_str_op_1       = _{ op_regex_match | op_not_regex_match | op_contain | op_not_contain | op_like | op_not_like | op_equal | op_not_equal }
 _ff_str_op_n       = _{ op_in | op_not_in }


### PR DESCRIPTION
This PR adds support for numbers in scientific notation (e.g., `1e10`, `3.787e-04`) across parsing, formatting, and query operations.

#### Problem

The application did not properly handle numbers in scientific notation, leading to several issues:

1. **Parsing**: Numbers like `1e10` or `1.5e-3` were not recognized as floating-point numbers
2. **Formatting**: String values that looked like scientific notation (e.g., `"1e10"`) were incorrectly formatted without quotes, treating them as keywords
3. **Query operations**: Numeric comparison and equality operators didn't work with scientific notation in filter expressions

This caused incorrect behavior when processing log data containing scientific notation, which is common in scientific computing, performance metrics, and financial data.

#### Solution

Enhanced number recognition and parsing throughout the codebase to properly identify and handle scientific notation with support for:
- Basic scientific notation: `1e10`, `1E10`
- Decimal coefficients: `1.5e10`
- Negative exponents: `1e-10`
- Positive exponents (explicit): `1e+10`
- Negative base values: `-1.5e-10`

#### Changes

**Number parsing (`src/model.rs`):**
- Updated `Number::from_str` to detect `e` or `E` in addition to `.` as indicators of floating-point numbers
- Numbers containing `e`/`E` are now parsed as `Number::Float` instead of attempting integer parsing

**Number recognition (`src/number/tests.rs`):**
- Enhanced `looks_like_number` function validation with comprehensive test cases
- Added test coverage for all scientific notation variants
- Added negative test cases for invalid formats (e.g., `1e`, `e10`, `1ee10`, `1e10.5`)

**Formatting (`src/formatting.rs`):**
- Fixed quote detection for string values to prevent scientific notation strings from being treated as keywords
- Added `!looks_like_number(&buf[begin..])` check to ensure numeric-looking strings are properly quoted

**Query support (`src/query.pest`):**
- Added `op_equal` and `op_not_equal` to numeric field filter operators (`_ff_num_op_1`)
- Enables equality/inequality comparisons with scientific notation in queries (e.g., `.value = 1e10`)

**Comprehensive test coverage:**
- **`src/model/tests.rs`**: 23 new test cases for `Number::from_str` covering valid and invalid scientific notation
- **`src/number/tests.rs`**: Enhanced test cases with descriptive names for all number format variants
- **`src/formatting/tests.rs`**: 16 new test cases for formatting numeric and string values in scientific notation
- **`src/query/tests.rs`**: 24 new test cases for query operations with scientific notation (equality, comparison, range operators)

#### Test Examples

**Parsing:**
```rust
"1e10".parse::<Number>()      // Number::Float(1e10)
"1.5e-10".parse::<Number>()   // Number::Float(1.5e-10)
```

**Formatting:**
```rust
{"val":1e10}    → val=1e10           // Numeric value (unquoted)
{"val":"1e10"}  → val="1e10"         // String value (quoted)
```

**Querying:**
```rust
.value = 1e10                        // Equality
.value > 1e9                         // Greater than
.value in (1e5, 1e6, 1e7)            // Set membership
```

---

This enhancement ensures that scientific notation is a first-class citizen in number handling, making the tool suitable for processing logs from scientific and technical applications.