### PR TITLE
fix: escape del (0x7F) character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "encstr"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "memchr",
 ]
@@ -1129,7 +1129,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.34.1-alpha.1"
+version = "0.34.1-alpha.2"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.34.1-alpha.1"
+version = "0.34.1-alpha.2"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/crate/encstr/Cargo.toml
+++ b/crate/encstr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encstr"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 description = "Encoded string"
 repository.workspace = true

--- a/crate/encstr/src/json.rs
+++ b/crate/encstr/src/json.rs
@@ -103,7 +103,7 @@ impl<'a> Handler for Appender<'a> {
             },
             Token::Sequence(s) => {
                 let mut ss = s.as_bytes();
-                while let Some(pos) = ss.iter().position(|x| matches!(x, 0..=0x1f | b'"' | b'\\')) {
+                while let Some(pos) = ss.iter().position(|x| matches!(x, 0..=0x1f | b'"' | b'\\' | 0x7f)) {
                     self.buffer.extend(&ss[..pos]);
                     self.handle_escape(ss[pos]);
                     ss = &ss[pos + 1..];
@@ -360,6 +360,7 @@ static ESCAPE: [bool; 256] = {
     const CT: bool = true; // control character \x00..=\x1F
     const QU: bool = true; // quote \x22
     const BS: bool = true; // backslash \x5C
+    const DL: bool = true; // DEL \x7F
     const __: bool = false; // allow unescaped
     [
         //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
@@ -370,7 +371,7 @@ static ESCAPE: [bool; 256] = {
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
         __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
-        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, DL, // 7
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
         __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A

--- a/src/formatting/tests.rs
+++ b/src/formatting/tests.rs
@@ -1288,6 +1288,53 @@ mod string {
     }
 
     // ---
+    // Test 11b: ValueFormatDoubleQuoted - complete control character suite
+    // ---
+
+    #[rstest]
+    // 0x00-0x08
+    #[case::nul("\x00", r#""\u0000""#)]
+    #[case::soh("\x01", r#""\u0001""#)]
+    #[case::stx("\x02", r#""\u0002""#)]
+    #[case::etx("\x03", r#""\u0003""#)]
+    #[case::eot("\x04", r#""\u0004""#)]
+    #[case::enq("\x05", r#""\u0005""#)]
+    #[case::ack("\x06", r#""\u0006""#)]
+    #[case::bel("\x07", r#""\u0007""#)]
+    #[case::bs("\x08", r#""\b""#)]
+    // 0x09-0x0d (special handling)
+    #[case::ht("\x09", r#""\t""#)]
+    #[case::lf("\x0a", r#""\n""#)]
+    #[case::vt("\x0b", r#""\u000b""#)]
+    #[case::ff("\x0c", r#""\f""#)]
+    #[case::cr("\x0d", r#""\r""#)]
+    // 0x0e-0x1f
+    #[case::so("\x0e", r#""\u000e""#)]
+    #[case::si("\x0f", r#""\u000f""#)]
+    #[case::dle("\x10", r#""\u0010""#)]
+    #[case::dc1("\x11", r#""\u0011""#)]
+    #[case::dc2("\x12", r#""\u0012""#)]
+    #[case::dc3("\x13", r#""\u0013""#)]
+    #[case::dc4("\x14", r#""\u0014""#)]
+    #[case::nak("\x15", r#""\u0015""#)]
+    #[case::syn("\x16", r#""\u0016""#)]
+    #[case::etb("\x17", r#""\u0017""#)]
+    #[case::can("\x18", r#""\u0018""#)]
+    #[case::em("\x19", r#""\u0019""#)]
+    #[case::sub("\x1a", r#""\u001a""#)]
+    #[case::esc("\x1b", r#""\u001b""#)]
+    #[case::fs("\x1c", r#""\u001c""#)]
+    #[case::gs("\x1d", r#""\u001d""#)]
+    #[case::rs("\x1e", r#""\u001e""#)]
+    #[case::us("\x1f", r#""\u001f""#)]
+    // DEL (0x7F) - Now escaped to match jq and best practice
+    #[case::del("\x7f", r#""\u007f""#)]
+    fn test_value_format_double_quoted_control_chars(#[case] input: &str, #[case] expected: &str) {
+        // Tests the complete control character suite (0x00-0x1F, 0x7F)
+        assert_formats_to(&ValueFormatDoubleQuoted, input, expected);
+    }
+
+    // ---
     // Test 12: MessageFormatAutoQuoted - empty handling
     // ---
 
@@ -1592,6 +1639,53 @@ mod string {
     #[case::vertical_tab("\x0b", r#""\u000b""#)]
     #[case::form_feed("\x0c", r#""\f""#)]
     fn test_message_format_double_quoted(#[case] input: &str, #[case] expected: &str) {
+        assert_formats_to(&MessageFormatDoubleQuoted, input, expected);
+    }
+
+    // ---
+    // Test 31b: MessageFormatDoubleQuoted - complete control character suite
+    // ---
+
+    #[rstest]
+    // 0x00-0x08
+    #[case::nul("\x00", r#""\u0000""#)]
+    #[case::soh("\x01", r#""\u0001""#)]
+    #[case::stx("\x02", r#""\u0002""#)]
+    #[case::etx("\x03", r#""\u0003""#)]
+    #[case::eot("\x04", r#""\u0004""#)]
+    #[case::enq("\x05", r#""\u0005""#)]
+    #[case::ack("\x06", r#""\u0006""#)]
+    #[case::bel("\x07", r#""\u0007""#)]
+    #[case::bs("\x08", r#""\b""#)]
+    // 0x09-0x0d (special handling)
+    #[case::ht("\x09", r#""\t""#)]
+    #[case::lf("\x0a", r#""\n""#)]
+    #[case::vt("\x0b", r#""\u000b""#)]
+    #[case::ff("\x0c", r#""\f""#)]
+    #[case::cr("\x0d", r#""\r""#)]
+    // 0x0e-0x1f
+    #[case::so("\x0e", r#""\u000e""#)]
+    #[case::si("\x0f", r#""\u000f""#)]
+    #[case::dle("\x10", r#""\u0010""#)]
+    #[case::dc1("\x11", r#""\u0011""#)]
+    #[case::dc2("\x12", r#""\u0012""#)]
+    #[case::dc3("\x13", r#""\u0013""#)]
+    #[case::dc4("\x14", r#""\u0014""#)]
+    #[case::nak("\x15", r#""\u0015""#)]
+    #[case::syn("\x16", r#""\u0016""#)]
+    #[case::etb("\x17", r#""\u0017""#)]
+    #[case::can("\x18", r#""\u0018""#)]
+    #[case::em("\x19", r#""\u0019""#)]
+    #[case::sub("\x1a", r#""\u001a""#)]
+    #[case::esc("\x1b", r#""\u001b""#)]
+    #[case::fs("\x1c", r#""\u001c""#)]
+    #[case::gs("\x1d", r#""\u001d""#)]
+    #[case::rs("\x1e", r#""\u001e""#)]
+    #[case::us("\x1f", r#""\u001f""#)]
+    // DEL (0x7F) - Now escaped to match jq and best practice
+    #[case::del("\x7f", r#""\u007f""#)]
+    fn test_message_format_double_quoted_control_chars(#[case] input: &str, #[case] expected: &str) {
+        // Tests the complete control character suite (0x00-0x1F, 0x7F)
         assert_formats_to(&MessageFormatDoubleQuoted, input, expected);
     }
 


### PR DESCRIPTION
This PR fixes a bug where the DEL control character (ASCII 0x7F) was not being properly escaped in JSON string output, making the output inconsistent with standard JSON encoders like `jq` and JSON best practices.

#### Problem

The DEL character (0x7F) is a control character that should be escaped in JSON strings, but the current implementation only escaped characters in the range 0x00-0x1F along with `"` and `\`. This meant that DEL characters would pass through unescaped, which could cause:
- Inconsistent behavior compared to standard JSON tools
- Potential rendering issues in terminals and text editors
- Non-conformance with JSON best practices for escaping non-printable characters

#### Solution

Updated the JSON string handling in the `encstr` crate to properly detect and escape the DEL character (0x7F) as `\u007f`.

#### Changes

**Core JSON encoding logic (`crate/encstr/src/json.rs`):**
- Modified the escape detection pattern from `0..=0x1f | b'"' | b'\\'` to include `| 0x7f`
- Updated the `ESCAPE` lookup table to mark position 0x7F (DEL) as requiring escape
- Added documentation comment for the DEL character in the escape table

**Comprehensive test coverage (`src/formatting/tests.rs`):**
- Added complete control character test suite for `ValueFormatDoubleQuoted` (Test 11b)
  - Tests all control characters 0x00-0x1F
  - Tests DEL character (0x7F) with expected output `"\u007f"`
- Added complete control character test suite for `MessageFormatDoubleQuoted` (Test 31b)
  - Mirrors the same comprehensive coverage for message formatting
- Each test case is named with the ASCII mnemonic (e.g., `nul`, `soh`, `del`) for clarity

#### Behavior Change

**Before:**
```rust
"\x7f" → "\x7f" (unescaped)
```

**After:**
```rust
"\x7f" → "\u007f" (properly escaped)
```