### PR TITLE
fix: fix formatting of whitespace-only values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.3"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.3"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"


### PR DESCRIPTION
This PR fixes a bug in the formatting logic where values containing only whitespace characters (spaces, tabs, newlines) were being incorrectly formatted as empty strings instead of being properly quoted.

#### Problem

When formatting values that consisted entirely of whitespace characters, the auto-trim functionality would remove all content, resulting in empty output. This was incorrect because:
1. Whitespace-only values should be preserved to maintain data fidelity
2. Such values should be quoted to clearly indicate they are non-empty strings

#### Solution

The fix introduces a flexible auto-trim mechanism with flags:

- **Added `AutoTrimFlag` enum** with a `PreserveWhiteSpaceOnly` flag to control trimming behavior
- **Modified `WithAutoTrim` trait** to accept flags that determine whether whitespace-only content should be preserved
- **Updated `ValueFormatAuto`** to preserve whitespace-only values by passing the `PreserveWhiteSpaceOnly` flag
- **Enhanced logic** to properly quote whitespace-only values (e.g., `"   "`, `"\t\t"`)

#### Changes

**Core formatting logic (`src/formatting.rs`):**
- Made `WithAutoTrim` trait accept an `AutoTrimFlags` parameter
- Added `AutoTrimFlag` enum with `PreserveWhiteSpaceOnly` variant using `EnumSet`
- Updated `with_auto_trim` implementation to check flags before truncating whitespace-only content
- Modified `ValueFormatAuto` to preserve whitespace-only values while still trimming trailing whitespace from mixed content
- Updated quoting condition to ensure whitespace-only values are quoted

**Tests (`src/formatting/tests.rs`):**
- Updated test expectations for whitespace-only inputs (e.g., `"   "` now formats as `"   "` instead of empty string)
- Added new error handling test for invalid JSON
- Updated test comments to reflect correct behavior

---

This fix ensures that all values, including those containing only whitespace, are formatted correctly and unambiguously, improving data integrity and user experience.
