### PR TITLE
build(deps): replace bincode with ciborium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,26 +150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,19 +1109,19 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.0-alpha.3"
+version = "0.35.0-alpha.4"
 dependencies = [
  "anstream",
  "anyhow",
  "assert_matches",
  "base32",
- "bincode",
  "byte-strings",
  "bytefmt",
  "capnp",
  "capnpc",
  "chrono",
  "chrono-tz",
+ "ciborium",
  "clap",
  "clap_complete",
  "clap_mangen",
@@ -2535,12 +2515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "utf8-supported"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,12 +2534,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0-alpha.3"
+version = "0.35.0-alpha.4"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"
@@ -38,11 +38,11 @@ name = "bench"
 
 [dependencies]
 anstream = "0.6"
-bincode = { version = "2", features = ["serde"] }
 bytefmt = "0.1"
 capnp = "0.24"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 chrono-tz = { version = "0.10", features = ["serde"] }
+ciborium = "0.2"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_mangen = { workspace = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,9 +36,9 @@ pub enum Error {
     #[error(transparent)]
     Capnp(#[from] capnp::Error),
     #[error(transparent)]
-    BincodeEncode(#[from] bincode::error::EncodeError),
+    CiboriumSerialize(#[from] ciborium::ser::Error<std::io::Error>),
     #[error(transparent)]
-    BincodeDecode(#[from] bincode::error::DecodeError),
+    CiboriumDeserialize(#[from] ciborium::de::Error<std::io::Error>),
     #[error(transparent)]
     Boxed(#[from] Box<dyn std::error::Error + std::marker::Send>),
     #[error("file {filename:?} not found")]


### PR DESCRIPTION
## Dependency Maintenance

This change replaces unmaintained serialization dependencies with a single, actively maintained alternative.

### Breaking Change

⚠️ **Existing index cache files will need to be regenerated** after this update. The application will automatically create new index files when processing log files.

If you have cached index files from previous versions, they will be incompatible with this version and should be deleted. Index files are typically stored in your system's cache directory and will be automatically recreated as needed.

### Changes

**Replaced `bincode` with `ciborium`** for all serialization needs:
- Used for persistent index file storage (headers and metadata)
- Used for configuration hash computation
- `ciborium` is the recommended modern CBOR library for Rust
- Provides deterministic serialization, ensuring consistent hashes
- CBOR is an IETF standard (RFC 8949) with broad ecosystem support
- Single dependency simplifies the codebase

### Background

The `bincode` crate has been flagged as unmaintained by cargo-audit. The original fix attempted to use both `rkyv` and `postcard`, but `postcard` transitively depends on `atomic-polyfill`, which is also unmaintained.

By consolidating on `ciborium` for both use cases, we:
- Eliminate all unmaintained dependencies
- Use a single, well-established serialization format (CBOR/RFC 8949)
- Simplify the dependency tree
- Ensure long-term reliability and security

`ciborium` is actively maintained by the Enarx project and is the recommended successor to both `serde_cbor` (archived in 2021) and the original `cbor` crate by BurntSushi.