### PR TITLE
build(deps): replace `htp` with `chrono-english`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,11 +284,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-english"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a56613410c9249673f4676ab8d27c70949814accb27b6b738009e2ff1034a1"
+dependencies = [
+ "chrono",
+ "scanlex",
 ]
 
 [[package]]
@@ -1111,7 +1119,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.0-alpha.10"
+version = "0.35.0-alpha.11"
 dependencies = [
  "anstream",
  "anyhow",
@@ -1122,6 +1130,7 @@ dependencies = [
  "capnp",
  "capnpc",
  "chrono",
+ "chrono-english",
  "chrono-tz",
  "ciborium",
  "clap",
@@ -1152,7 +1161,6 @@ dependencies = [
  "heapless",
  "heapopt",
  "hex",
- "htp",
  "humantime",
  "itertools 0.14.0",
  "itoa",
@@ -1190,7 +1198,7 @@ dependencies = [
  "strum",
  "styled-help",
  "terminal_size",
- "thiserror 2.0.17",
+ "thiserror",
  "titlecase",
  "toml",
  "unicode-segmentation",
@@ -1204,17 +1212,6 @@ dependencies = [
  "winapi-util",
  "wyhash",
  "yaml-peg",
-]
-
-[[package]]
-name = "htp"
-version = "0.4.2"
-source = "git+https://github.com/pamburus/htp.git#3fd9234bd64807d855faf404f7ea5f77672c5e7e"
-dependencies = [
- "chrono",
- "pest",
- "pest_derive",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1956,7 +1953,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror",
 ]
 
 [[package]]
@@ -2183,6 +2180,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scanlex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
 
 [[package]]
 name = "semver"
@@ -2451,31 +2454,11 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.17",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0-alpha.10"
+version = "0.35.0-alpha.11"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"
@@ -48,6 +48,7 @@ anstream = "0.6"
 bytefmt = "0.1"
 capnp.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
+chrono-english = "0.1"
 chrono-tz = { version = "0.10", features = ["serde"] }
 ciborium = "0.2"
 clap = { workspace = true }
@@ -75,7 +76,6 @@ flate2 = "1"
 heapless = "0.9"
 heapopt = { path = "./crate/heapopt" }
 hex = "0.4"
-htp = { git = "https://github.com/pamburus/htp.git" }
 humantime = "2"
 itertools = "0.14"
 itoa = { version = "1", default-features = false }

--- a/nix/cargo-hashes.nix
+++ b/nix/cargo-hashes.nix
@@ -3,6 +3,5 @@
 # used in Cargo.lock. Update these hashes when dependencies change.
 {
   "clap_mangen-0.2.31" = "sha256-9PqsAM9akOnIWtuEZd0BHy1oMz7JIs/qBQzBwjznuF0=";
-  "htp-0.4.2" = "sha256-oYLN0aCLIeTST+Ib6OgWqEgu9qyI0n5BDtIUIIThLiQ=";
   "wildflower-0.3.0" = "sha256-vv+ppiCrtEkCWab53eutfjHKrHZj+BEAprV5by8plzE=";
 }


### PR DESCRIPTION
# Replace `htp` with `chrono-english` for human-readable time parsing

## Summary

This PR replaces the `htp` time parsing library with `chrono-english` for parsing human-readable time expressions in filter options like `--since` and `--until`.

## Motivation

The `htp` library is unmaintained, while `chrono-english` is an actively maintained library with broader community support and similar functionality for parsing English date/time expressions.

## What Changed

### ❌ No Longer Supported

| Expression | htp | chrono-english | Replacement |
|------------|-----|----------------|-------------|
| `"friday at 19:00"` | ✅ Works | ❌ Error | Use `"last friday 19:00"` |
| `"last friday at 19:00"` | ✅ Works | ❌ Error | Use `"last friday 19:00"` |
| `"monday at 6 am"` | ✅ Works | ❌ Error | Use `"last monday 6:00"` |

### ✨ Newly Supported

| Expression | htp | chrono-english | Notes |
|------------|-----|----------------|-------|
| `"last friday 19:00"` | ❌ Error | ✅ Works | Time without "at" keyword |
| `"last April"` | ❌ Error | ✅ Works | Month references (past) |
| `"april"` | ❌ Error | ✅ Works | Bare month (auto-prefixed with "last") |
| `"dec"` | ❌ Error | ✅ Works | Short month name (auto-prefixed) |
| `"1 April 2025"` | ❌ Error | ✅ Works | Long date format |
| `"2025-12-15"` | ❌ Error | ✅ Works | ISO date format |
| `"2025"` | ❌ Error | ✅ Works | Year-only (Jan 1st) |
| `"2026"` | ❌ Error | ✅ Works | Year-only (Jan 1st) |

### ✅ Works the Same in Both

| Expression | Result | Use Case |
|------------|--------|----------|
| `"1 hour ago"` | 1 hour ago | ✅ Common |
| `"2 days ago"` | 2 days ago | ✅ Common |
| `"1 week ago"` | 1 week ago | ✅ Common |
| `"now"` | Current time | ✅ Common |
| `"last friday"` | Previous Friday | ✅ Common |
| `"last monday"` | Previous Monday | ✅ Common |
| `"7am"` | Today at 7 AM | ✅ Common |
| `"19:00"` | Today at 19:00 | ✅ Common |
| `-1h`, `-2d`, `-1w` | Explicit past durations | ✅ Common |



## Migration Guide

### Must Update

If you're using **weekday with "at" + time**:

```bash
# Before (htp)
hl --since "friday at 19:00" app.log
hl --since "monday at 6 am" app.log

# After (chrono-english) - remove "at", add "last"
hl --since "last friday 19:00" app.log
hl --since "last monday 6:00" app.log
```

### No Changes Needed

These continue to work identically:

```bash
# Relative durations (most common usage)
hl --since -1h app.log
hl --since -2d app.log
hl --since -1w app.log

# Natural language "ago" syntax
hl --since "1 hour ago" app.log
hl --since "2 days ago" app.log

# Named days
hl --since yesterday app.log
hl --since today app.log

# Weekdays with "last" modifier
hl --since "last friday" app.log
hl --since "last monday" app.log

# Bare times
hl --since 7am app.log
hl --since 19:00 app.log
```

## New Capabilities

### Month-based filtering

```bash
# Logs from last April
hl --since "last April" app.log

# Logs from specific date
hl --since "1 April 2025" app.log
hl --since "2025-12-15" app.log
```

### Weekday with time (no "at" needed)

```bash
# Last Friday at 7 PM
hl --since "last friday 19:00" app.log

# Last Monday at 9 AM
hl --since "last monday 9:00" app.log
```

## Common Patterns

| Use Case | Syntax |
|----------|--------|
| Last hour | `--since -1h` or `--since "1 hour ago"` |
| Last day | `--since -1d` or `--since yesterday` |
| Last week | `--since -1w` or `--since "1 week ago"` |
| Last Friday | `--since "last friday"` or `--since friday` |
| Last Friday evening | `--since "last friday 19:00"` ✨ |
| Last month (April) | `--since "last April"` or `--since april` ✨ |

✨ = New capability

## Technical Details

- **Dependency change**: `htp` (git fork) → `chrono-english 0.1` (crates.io)
- **Dialect**: Uses `Dialect::Us` for consistent date interpretation
- **Backward compatibility workarounds**:
  - Bare weekday names (e.g., `"friday"`) are automatically prefixed with `"last "` to maintain htp behavior
  - Bare month names (e.g., `"april"`, `"dec"`) are automatically prefixed with `"last "` for consistent behavior
  - `"today"` and `"yesterday"` are adjusted to start-of-day (00:00) instead of current time
- **Ambiguity prevention**: Bare durations like `1h`, `2d` are rejected to prevent confusion
- **Timezone handling**: Honors `--time-zone` and `--local` options as before