### PR TITLE
fix(format): `%:z` and `%::z` timezone formats now include colons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.0-alpha.14"
+version = "0.35.0-alpha.15"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0-alpha.14"
+version = "0.35.0-alpha.15"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/src/datefmt.rs
+++ b/src/datefmt.rs
@@ -711,7 +711,7 @@ where
                     f.numeric(dt.and_utc().timestamp(), 10, flags);
                 }
             }
-            Item::TimeZoneOffset((_, precision)) => {
+            Item::TimeZoneOffset((flags, precision)) => {
                 if sts.timezone().is_utc() {
                     f.char(b'+');
                     f.char(b'0');
@@ -725,6 +725,9 @@ where
                     }
                 }
                 if precision == 0 || precision > 1 {
+                    if !flags.contains(NoDelimiters) {
+                        f.char(b':');
+                    }
                     if let Some(minute) = sts.timezone().minute() {
                         f.text(minute.as_bytes());
                     } else {
@@ -733,6 +736,9 @@ where
                     }
                 }
                 if precision == 0 || precision > 2 {
+                    if !flags.contains(NoDelimiters) {
+                        f.char(b':');
+                    }
                     f.char(b'0');
                     f.char(b'0');
                 }


### PR DESCRIPTION
### Before
`%Y-%m-%d %T %:z`
```
2025-08-25 16:36:50 +0000
```
`%Y-%m-%d %T %::z`
```
2025-08-25 16:36:50 +000000
```
### After
`%Y-%m-%d %T %:z`
```
2025-08-25 16:36:50 +00:00
```
`%Y-%m-%d %T %::z`
```
2025-08-25 16:36:50 +00:00:00
```