### PR TITLE
fix: disallow inline expansion for message in non-inline modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.1-alpha.1"
+version = "0.35.1-alpha.2"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.1-alpha.1"
+version = "0.35.1-alpha.2"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"


### PR DESCRIPTION
This PR provides follow-up fixes for the recently implemented expansion feature. These changes address message expansion issues and edge cases identified shortly after the initial merge.

Related PR: #1259 