### PR TITLE
fix(config): change default show mode for time and level fields to 'always'

### DIFF
--- a/etc/defaults/config.toml
+++ b/etc/defaults/config.toml
@@ -55,7 +55,9 @@ hide = []
 #
 # Configuration of the predefined "time" field.
 [fields.predefined.time]
-show = "auto"
+# Determines when to show the time field automatically based on the presence of time variants.
+# Options: ["always", "auto"].
+show = "always"
 names = [
   "ts",
   "TS",
@@ -76,7 +78,9 @@ names = ["logger", "LOGGER", "Logger", "span.name"]
 
 # Configuration of the predefined "level" field.
 [fields.predefined.level]
-show = "auto"
+# Determines when to show the level field automatically based on the presence of level variants.
+# Options: ["always", "auto"].
+show = "always"
 
 # Common levels.
 [[fields.predefined.level.variants]]
@@ -121,7 +125,7 @@ names = []
 
 [formatting]
 #
-# Flatten nested fields by joining them with a dot. Options: [always, never].
+# Flatten nested fields by joining them with a dot. Options: ["always", "never"].
 flatten = "always"
 
 # Message format [auto-quoted, always-quoted, always-double-quoted, delimited, raw]:

--- a/src/settings/tests.rs
+++ b/src/settings/tests.rs
@@ -21,7 +21,7 @@ fn test_load_settings_k8s() {
         settings.fields.predefined.time,
         TimeField(Field {
             names: vec!["ts".into()],
-            show: FieldShowOption::Auto,
+            show: FieldShowOption::Always,
         })
     );
     assert_eq!(settings.time_format, "%b %d %T.%3N");


### PR DESCRIPTION
# Change `show` mode for time and level fields to `always`

## Summary

Changes the default `show` setting from `auto` to `always` for the predefined `time` and `level` fields in the default configuration.

## Motivation

The `auto` mode conditionally shows/hides fields based on whether certain field variants are present in the logs. While this can make output more compact, it leads to inconsistent formatting:

- Headers and field positions shift depending on log content
- Output format becomes unpredictable
- Confusing user experience when fields appear/disappear

The `always` mode provides consistent, predictable output format regardless of log content.

## Changes

### Configuration Changes

**File:** [etc/defaults/config.toml](etc/defaults/config.toml)

Changed for both `time` and `level` predefined fields:
```diff
-show = "auto"
+show = "always"
```

Also added inline documentation explaining the available options:
```toml
# Determines when to show the time field automatically based on the presence of time variants.
# Options: ["always", "auto"].
show = "always"
```

### Behavior Impact

**Before (auto mode):**
- Time field only shown when timestamp variants detected
- Level field only shown when level variants detected
- Output format varies based on log content

**After (always mode):**
- Time field always shown (with placeholders if no timestamp)
- Level field always shown (with placeholders if no level)
- Consistent output format across all logs

## Examples

### Before (show = "auto")
```
message without timestamp
2026-01-01 10:30:45.123 message with timestamp
[INF] message with level
2026-01-01 10:30:45.123 [INF] message with both
```

### After (show = "always")
```
####-##-## ##:##:##.### [###] message without timestamp
2026-01-01 10:30:45.123 [###] message with timestamp
####-##-## ##:##:##.### [INF] message with level
2026-01-01 10:30:45.123 [INF] message with both
```

## Migration

Users who prefer the old behavior can override in user config (`~/.config/hl/config.toml`):
   ```toml
   [fields.predefined.time]
   show = "auto"
   
   [fields.predefined.level]
   show = "auto"
   ```

## Breaking Change

⚠️ **This is a minor breaking change** in default behavior. The output format will be more consistent but may look different for users relying on auto-hiding of these fields.