### PR TITLE
ci(release): use dynamic repository variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,10 @@ jobs:
           # Find all TOML files with schema references (both relative and absolute) and update them
           # Matches both:
           # - Relative: #:schema (../)+schema/...
-          # - Absolute: #:schema https://raw.githubusercontent.com/pamburus/hl/[ref]/schema/...
+          # - Absolute: #:schema https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/[ref]/schema/...
           find . -name "*.toml" -type f -exec grep -l "#:schema" {} \; | while read -r file; do
             echo "Updating schema reference in ${file}"
-            sed -i.bak -E 's|#:schema ((\.\./)+\|https://raw\.githubusercontent\.com/pamburus/hl/[^/]+/)schema/|#:schema https://raw.githubusercontent.com/pamburus/hl/v'"${VERSION}"'/schema/|g' "${file}"
+            sed -i.bak -E 's|#:schema ((\.\./)+\|https://raw\.githubusercontent\.com/${{ github.repository_owner }}/${{ github.repository }}/[^/]+/)schema/|#:schema https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/v'"${VERSION}"'/schema/|g' "${file}"
             rm -f "${file}.bak"
           done
 
@@ -132,12 +132,12 @@ jobs:
           VERSION=${{ steps.update-version.outputs.version }}
 
           # Find all JSON schema files with schema references and update them
-          find . -name "*.schema.json" -type f -exec grep -l "https://raw.githubusercontent.com/pamburus/hl/" {} \; | while read -r file; do
+          find . -name "*.schema.json" -type f -exec grep -l "https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/" {} \; | while read -r file; do
             echo "Updating schema reference in ${file}"
             jq --arg version "v${VERSION}" '
               walk(
-                if type == "string" and test("https://raw.githubusercontent.com/pamburus/hl/[^/]+/schema/") then
-                  gsub("https://raw.githubusercontent.com/pamburus/hl/[^/]+/schema/"; "https://raw.githubusercontent.com/pamburus/hl/\($version)/schema/")
+                if type == "string" and test("https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/[^/]+/schema/") then
+                  gsub("https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/[^/]+/schema/"; "https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/\($version)/schema/")
                 else
                   .
                 end


### PR DESCRIPTION
Replace hardcoded repository references with GitHub context variables to make the workflow more portable across forks and repository transfers.