### PR TITLE
fix: preserve all unparsed prefix lines and fix raw output input badges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.3-alpha.2"
+version = "0.35.3-alpha.3"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.3-alpha.2"
+version = "0.35.3-alpha.3"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1017,10 +1017,21 @@ impl<'a, Formatter: RecordWithSourceFormatter, Filter: RecordFilter> SegmentProc
                 let record = self.parser.parse(&ar.record);
                 if record.matches(&self.filter) {
                     let begin = buf.len();
-                    buf.extend(prefix.as_bytes());
-                    buf.extend(ar.prefix);
-                    if ar.prefix.last().map(|&x| x == b' ') == Some(false) {
-                        buf.push(b' ');
+                    if ar.prefix.is_empty() {
+                        buf.extend(prefix.as_bytes());
+                    } else {
+                        let mut first = true;
+                        for line in SmartNewLine.into_searcher().split(ar.prefix) {
+                            if !first {
+                                buf.push(b'\n');
+                            }
+                            first = false;
+                            buf.extend(prefix.as_bytes());
+                            buf.extend(line);
+                        }
+                        if ar.prefix.last().map(|&x| x == b' ') == Some(false) {
+                            buf.push(b' ');
+                        }
                     }
                     let prefix_range = begin..buf.len();
                     self.formatter

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -20,6 +20,7 @@ use crate::{
     filtering::IncludeExcludeSetting,
     fmtx::{OptimizedBuf, Push, aligned_left},
     model::{self, Caller, Level, RawValue},
+    scanning::{Delimit, SearchExt, SmartNewLine},
     settings::{self, AsciiMode, ExpansionMode, Formatting, ResolvedPunctuation},
     syntax::*,
     theme::{Element, Styler, StylingPush, Theme},
@@ -143,8 +144,16 @@ pub struct RawRecordFormatter {}
 
 impl RecordWithSourceFormatter for RawRecordFormatter {
     #[inline(always)]
-    fn format_record(&self, buf: &mut Buf, _prefix: Range<usize>, rec: model::RecordWithSource) {
-        buf.extend_from_slice(rec.source);
+    fn format_record(&self, buf: &mut Buf, prefix: Range<usize>, rec: model::RecordWithSource) {
+        let mut first = true;
+        for line in SmartNewLine.into_searcher().split(rec.source) {
+            if !first {
+                buf.push(b'\n');
+                buf.extend_from_within(prefix.clone());
+            }
+            first = false;
+            buf.extend_from_slice(line);
+        }
     }
 }
 

--- a/src/formatting/tests.rs
+++ b/src/formatting/tests.rs
@@ -624,6 +624,18 @@ fn test_record_with_source_formatter_arc() {
 }
 
 #[test]
+fn test_raw_record_formatter_multiline_with_prefix() {
+    let formatter = RawRecordFormatter {};
+    let rec = Record::default();
+    let rec = rec.with_source(b"line1\nline2\nline3");
+    let mut buf = Buf::default();
+    buf.extend_from_slice(b"#0 | ");
+    let prefix_range = 0..buf.len();
+    formatter.format_record(&mut buf, prefix_range, rec);
+    assert_eq!(buf.as_slice(), b"#0 | line1\n#0 | line2\n#0 | line3");
+}
+
+#[test]
 fn test_delimited_message_with_colors() {
     let formatter = formatter()
         .with_message_format(new_message_format(MessageFormat::Delimited, "::"))

--- a/src/model.rs
+++ b/src/model.rs
@@ -998,12 +998,6 @@ impl RawRecordParser {
         let xn = prefix.len();
         let data = &chunk[xn..];
 
-        let prefix = if let Some(nl) = memchr::memrchr3(b'\r', b'\n', b'}', prefix) {
-            if prefix[nl] == b'}' { b"" } else { &prefix[nl + 1..] }
-        } else {
-            prefix
-        };
-
         let format = self.format.or_else(|| {
             if data.is_empty() {
                 None


### PR DESCRIPTION
Fix additional issues with auto-delimiter mode when processing mixed JSON and non-JSON input:

- All unparsed prefix lines before JSON blocks are now preserved and output, fixing data loss where previously only the last line of multi-line prefixes was shown
- Input badges are now correctly applied to all continuation lines in raw output mode (`--raw`) with multi-line JSON input

These fixes ensure complete preservation of unparsed content and consistent input badge display across all output modes.