### PR TITLE
fix: restore pre-0.35.0 delimiter behavior for `--allow-prefix` and `logfmt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.3-alpha.4"
+version = "0.35.3-alpha.5"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.3-alpha.4"
+version = "0.35.3-alpha.5"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/benches/bench/ws/hl/delimiter.rs
+++ b/benches/bench/ws/hl/delimiter.rs
@@ -30,15 +30,15 @@ pub(super) fn bench(c: &mut Criterion) {
             BatchSize::NumIterations(8192),
         ),
         (
-            "s1:smart-new-line:lf:e",
+            "s1:new-line:lf:e",
             Vec::from(samples::log::elk01::JSON),
-            Delimiter::SmartNewLine,
+            Delimiter::NewLine,
             BatchSize::NumIterations(8192),
         ),
         (
-            "s1:smart-new-line:lf:s",
+            "s1:new-line:lf:s",
             rotated(samples::log::elk01::JSON, 1),
-            Delimiter::SmartNewLine,
+            Delimiter::NewLine,
             BatchSize::NumIterations(8192),
         ),
     ];

--- a/build/ci/coverage.sh
+++ b/build/ci/coverage.sh
@@ -40,6 +40,16 @@ function clean() {
         crate/*/${LLVM_PROFILE_PATTERN:?}
 }
 
+function check_hash() {
+    local expected="$1"
+    local actual
+    actual=$(shasum -a 256 | cut -d' ' -f1)
+    if [ "$actual" != "$expected" ]; then
+        echo "${BASH_SOURCE[1]}:${BASH_LINENO[0]}: Hash mismatch: expected $expected, got $actual" >&2
+        return 1
+    fi
+}
+
 function test() {
     cargo test --tests --workspace
     cargo build
@@ -57,6 +67,47 @@ function test() {
     HL_DEBUG_LOG=info ${MAIN_EXECUTABLE:?} --config - sample/prometheus.log -P -o /dev/null
     echo "" | ${MAIN_EXECUTABLE:?} --config - --concurrency 4 > /dev/null
     echo "level=info" | ${MAIN_EXECUTABLE:?} --config - sample/prometheus.log -P -q 'level=x' 2> /dev/null > /dev/null || true
+
+    # Test delimiter options with combined fixture containing all log formats
+    local fixture="src/testing/assets/fixtures/delimiter/combined.log"
+    local hl="${MAIN_EXECUTABLE:?} --config - -P --color never"
+
+    # Default (no options): parses jsonl, logfmt, pretty; shows prefixed and pretty-stripped raw
+    $hl $fixture | check_hash "81e53d5944f93cfc5f26f9eca2c0a4cd99ec7ae48cfccf6f92011b66c6aa584d"
+    # --delimiter auto: same as default
+    $hl $fixture --delimiter auto | check_hash "81e53d5944f93cfc5f26f9eca2c0a4cd99ec7ae48cfccf6f92011b66c6aa584d"
+    # --delimiter crlf: parses jsonl, logfmt; shows prefixed, pretty, pretty-stripped raw
+    $hl $fixture --delimiter crlf | check_hash "1776b8f301b8809374bdb6fad936c5649f52d2a29c230c13db93db7b86a79e93"
+
+    # --input-format json: parses only json entries (jsonl, pretty, pretty-stripped)
+    $hl $fixture --input-format json | check_hash "32250d3814dd03f2c5692b31daa73e5273c80914a0c1935acc318ceeb16e9401"
+    # --input-format json --delimiter auto: same as above
+    $hl $fixture --input-format json --delimiter auto | check_hash "32250d3814dd03f2c5692b31daa73e5273c80914a0c1935acc318ceeb16e9401"
+    # --input-format json --delimiter crlf: parses only jsonl (single-line json)
+    $hl $fixture --input-format json --delimiter crlf | check_hash "0185e71755887aff184accfd23a8d3778d7d849d1b10a8ac7f0d828ddcbb8e80"
+    # --input-format json --allow-prefix: parses jsonl and prefixed json entries
+    $hl $fixture --input-format json --allow-prefix | check_hash "f6267579b4e3c4233af9f8dbd09110d34a5fc7556378ae134da3a2959e892e9d"
+
+    # --input-format logfmt: parses only logfmt entry
+    $hl $fixture --input-format logfmt | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
+    # --input-format logfmt --delimiter auto: same as above
+    $hl $fixture --input-format logfmt --delimiter auto | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
+    # --input-format logfmt --delimiter crlf: same as above
+    $hl $fixture --input-format logfmt --delimiter crlf | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
+    # --input-format logfmt --allow-prefix: same as above
+    $hl $fixture --input-format logfmt --allow-prefix | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
+
+    # --allow-prefix: parses jsonl, logfmt, prefixed, space-prefixed; shows pretty raw
+    $hl $fixture --allow-prefix | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
+    # --allow-prefix --delimiter auto: same as above
+    $hl $fixture --allow-prefix --delimiter auto | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
+    # --allow-prefix --delimiter crlf: same as above
+    $hl $fixture --allow-prefix --delimiter crlf | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
+
+    # Special delimiters: single test each
+    $hl $fixture --delimiter lf | check_hash "1776b8f301b8809374bdb6fad936c5649f52d2a29c230c13db93db7b86a79e93"
+    $hl $fixture --delimiter cr | check_hash "4fbecc426cb22b575ce64146a5229dde3923051366f4b3e6ffd24b2205ea6c18"
+    $hl $fixture --delimiter nul | check_hash "4fbecc426cb22b575ce64146a5229dde3923051366f4b3e6ffd24b2205ea6c18"
 }
 
 function merge() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,9 +45,7 @@ use crate::{
     input::{BlockEntry, Input, InputHolder, InputReference},
     model::{Filter, Parser, ParserSettings, RawRecord, Record, RecordFilter, RecordWithSourceConstructor},
     query::Query,
-    scanning::{
-        BufFactory, Delimit, Delimiter, Scanner, SearchExt, Segment, SegmentBuf, SegmentBufFactory, SmartNewLine,
-    },
+    scanning::{BufFactory, Delimit, Delimiter, NewLine, Scanner, SearchExt, Segment, SegmentBuf, SegmentBufFactory},
     settings::{AsciiMode, ExpansionMode, FieldShowOption, Fields, Formatting, InputInfo, ResolvedPunctuation},
     theme::{Element, StylingPush, SyncIndicatorPack, Theme},
     timezone::Tz,
@@ -1021,7 +1019,7 @@ impl<'a, Formatter: RecordWithSourceFormatter, Filter: RecordFilter> SegmentProc
                         buf.extend(prefix.as_bytes());
                     } else {
                         let mut first = true;
-                        for line in SmartNewLine.into_searcher().split(ar.prefix) {
+                        for line in NewLine.into_searcher().split(ar.prefix) {
                             if !first {
                                 buf.push(b'\n');
                             }
@@ -1048,7 +1046,7 @@ impl<'a, Formatter: RecordWithSourceFormatter, Filter: RecordFilter> SegmentProc
             if !remainder.is_empty() && self.show_unparsed() {
                 if !parsed_some || produced_some {
                     let mut should_prefix = !parsed_some;
-                    for line in SmartNewLine.into_searcher().split(remainder) {
+                    for line in NewLine.into_searcher().split(remainder) {
                         if should_prefix {
                             buf.extend(prefix.as_bytes());
                         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1636,7 +1636,7 @@ fn test_bug_multiline_json_missing_input_badges_on_closing_braces() {
     let input = input("{\n\"level\":\"info\",\n\"msg\":\"test\"\n}\n");
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.input_info = InputInfo::Minimal.into();
     let app = App::new(opts);
     app.run(vec![input], &mut output).unwrap();
@@ -1683,7 +1683,7 @@ fn test_bug_multiline_remainder_missing_input_badges() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.input_info = InputInfo::Minimal.into();
     let app = App::new(opts);
     app.run(vec![input], &mut output).unwrap();
@@ -1722,7 +1722,7 @@ fn test_bug_prefix_with_closing_brace_on_same_line() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.allow_prefix = true;
     let app = App::new(opts);
     app.run(vec![input], &mut output).unwrap();
@@ -1765,7 +1765,7 @@ fn test_bug_prefix_multiline_block_closing_brace_not_included() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.allow_prefix = true;
     let app = App::new(opts);
     app.run(vec![input], &mut output).unwrap();
@@ -1810,7 +1810,7 @@ fn test_bug_complex_pretty_broken_scenario() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.allow_prefix = true;
     opts.input_info = InputInfo::Minimal.into();
     let app = App::new(opts);
@@ -1876,7 +1876,7 @@ fn test_bug_continuation_lines_with_input_badges() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.input_info = InputInfo::Minimal.into();
     let app = App::new(opts);
     app.run(vec![input], &mut output).unwrap();
@@ -1908,7 +1908,7 @@ fn test_bug_multiline_unparsed_prefix_data_loss() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.allow_prefix = true;
     opts.input_info = InputInfo::Minimal.into();
     let app = App::new(opts);
@@ -1955,7 +1955,7 @@ fn test_bug_raw_output_missing_input_badges_on_continuation_lines() {
     let input = input(concat!("{\n", "\"level\":\"info\",\n", "\"msg\":\"test1\"\n", "}\n",));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.allow_prefix = true;
     opts.raw = true;
     opts.input_info = InputInfo::Minimal.into();
@@ -2012,7 +2012,7 @@ fn test_bug_comprehensive_multiline_prefix_remainder_raw() {
     ));
     let mut output = Vec::new();
     let mut opts = options();
-    opts.delimiter = Delimiter::Auto;
+    opts.delimiter = Delimiter::PrettyCompatible;
     opts.allow_prefix = true;
     opts.raw = true;
     opts.input_info = InputInfo::Minimal.into();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -431,8 +431,8 @@ pub struct Opt {
     /// • <c>lf</>: Line feed (\n)
     /// • <c>crlf</>: Carriage return + line feed (\r\n)
     /// • <c>nul</>: Null character (\0)
-    #[arg(long, env = "HL_DELIMITER", overrides_with = "delimiter", help_heading = heading::INPUT)]
-    pub delimiter: Option<Delimiter>,
+    #[arg(long, env = "HL_DELIMITER", default_value = "auto", overrides_with = "delimiter", help_heading = heading::INPUT)]
+    pub delimiter: Delimiter,
 
     /// Number of interrupts to ignore, i.e. Ctrl-C (SIGINT)
     #[arg(

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -20,7 +20,7 @@ use crate::{
     filtering::IncludeExcludeSetting,
     fmtx::{OptimizedBuf, Push, aligned_left},
     model::{self, Caller, Level, RawValue},
-    scanning::{Delimit, SearchExt, SmartNewLine},
+    scanning::{Delimit, NewLine, SearchExt},
     settings::{self, AsciiMode, ExpansionMode, Formatting, ResolvedPunctuation},
     syntax::*,
     theme::{Element, Styler, StylingPush, Theme},
@@ -146,7 +146,7 @@ impl RecordWithSourceFormatter for RawRecordFormatter {
     #[inline(always)]
     fn format_record(&self, buf: &mut Buf, prefix: Range<usize>, rec: model::RecordWithSource) {
         let mut first = true;
-        for line in SmartNewLine.into_searcher().split(rec.source) {
+        for line in NewLine.into_searcher().split(rec.source) {
             if !first {
                 buf.push(b'\n');
                 buf.extend_from_within(prefix.clone());

--- a/src/index/tests.rs
+++ b/src/index/tests.rs
@@ -395,7 +395,7 @@ fn test_indexer_with_auto_delimiter() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::Auto,
+            delimiter: Delimiter::PrettyCompatible,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -448,7 +448,7 @@ fn test_indexer_chronology_with_unsorted_entries() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::SmartNewLine,
+            delimiter: Delimiter::NewLine,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -483,7 +483,7 @@ fn test_indexer_with_empty_entries() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::SmartNewLine,
+            delimiter: Delimiter::NewLine,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -536,7 +536,7 @@ fn test_indexer_auto_delimiter_skips_continuation_lines() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::Auto,
+            delimiter: Delimiter::PrettyCompatible,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -562,7 +562,7 @@ fn test_indexer_with_mixed_valid_invalid_entries() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::SmartNewLine,
+            delimiter: Delimiter::NewLine,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -595,7 +595,7 @@ fn test_indexer_large_entries_across_blocks() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(1024u32).into(),
-            delimiter: Delimiter::SmartNewLine,
+            delimiter: Delimiter::NewLine,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -635,7 +635,7 @@ fn test_chronology_bitmap_structure() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(16384u32).into(),
-            delimiter: Delimiter::SmartNewLine,
+            delimiter: Delimiter::NewLine,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -667,11 +667,11 @@ fn test_indexer_delimiter_in_settings() {
 
     let settings_auto = IndexerSettings {
         buffer_size: nonzero!(1024u32).into(),
-        delimiter: Delimiter::Auto,
+        delimiter: Delimiter::PrettyCompatible,
         ..IndexerSettings::with_fs(vfs::mem::FileSystem::new())
     };
 
     // Verify delimiter is stored correctly
     assert_eq!(settings_json.delimiter, Delimiter::Json);
-    assert_eq!(settings_auto.delimiter, Delimiter::Auto);
+    assert_eq!(settings_auto.delimiter, Delimiter::PrettyCompatible);
 }

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -52,7 +52,7 @@ fn test_input() {
 
 #[test]
 fn test_input_tail() {
-    let input = Input::stdin().unwrap().tail(1, Delimiter::SmartNewLine).unwrap();
+    let input = Input::stdin().unwrap().tail(1, Delimiter::NewLine).unwrap();
     assert!(matches!(input.stream, Stream::Sequential(_)));
 
     for &(filename, requested, expected) in &[
@@ -63,7 +63,7 @@ fn test_input_tail() {
     ] {
         let input = Input::open(&PathBuf::from(filename))
             .unwrap()
-            .tail(requested, Delimiter::SmartNewLine)
+            .tail(requested, Delimiter::NewLine)
             .unwrap();
         let mut buf = Vec::new();
         let n = input.stream.into_sequential().read_to_end(&mut buf).unwrap();
@@ -197,7 +197,7 @@ fn test_indexed_input_file_random_access() {
                 ..IndexerSettings::with_fs(fs.clone())
             },
         );
-        let input = IndexedInput::open(&path, &indexer, Delimiter::SmartNewLine).unwrap();
+        let input = IndexedInput::open(&path, &indexer, Delimiter::NewLine).unwrap();
         let mut blocks = input.into_blocks().sorted().collect_vec();
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0].entries_valid(), 1);
@@ -340,7 +340,7 @@ fn test_input_tail_with_auto_delimiter() {
     let input = Input::new(reference, stream);
 
     // Request last 1 entry with Auto delimiter
-    let input = input.tail(1, Delimiter::Auto).unwrap();
+    let input = input.tail(1, Delimiter::PrettyCompatible).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -375,7 +375,7 @@ fn test_input_tail_ending_with_delimiter() {
     let input = Input::new(reference, stream);
 
     // Request last 1 entry
-    let input = input.tail(1, Delimiter::SmartNewLine).unwrap();
+    let input = input.tail(1, Delimiter::NewLine).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -410,7 +410,7 @@ fn test_input_tail_more_than_available() {
     let input = Input::new(reference, stream);
 
     // Request more entries than available
-    let input = input.tail(10, Delimiter::SmartNewLine).unwrap();
+    let input = input.tail(10, Delimiter::NewLine).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -428,7 +428,7 @@ fn test_input_tail_with_crlf() {
     let input = Input::new(reference, stream);
 
     // Request last 2 entries
-    let input = input.tail(2, Delimiter::SmartNewLine).unwrap();
+    let input = input.tail(2, Delimiter::NewLine).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -445,7 +445,7 @@ fn test_input_tail_partial_match_handling() {
     let reference = InputReference::Stdin;
     let input = Input::new(reference, stream);
 
-    let input = input.tail(3, Delimiter::SmartNewLine).unwrap();
+    let input = input.tail(3, Delimiter::NewLine).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -507,7 +507,7 @@ fn test_block_entry_methods() {
     let data = include_bytes!("testdata/two_messages.jsonl");
     let stream = Stream::RandomAccess(Box::new(Cursor::new(data)));
     let indexer = Indexer::<LocalFileSystem>::new(1, PathBuf::new(), IndexerSettings::with_fs(LocalFileSystem));
-    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::SmartNewLine, &indexer).unwrap();
+    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::NewLine, &indexer).unwrap();
 
     let blocks = input.into_blocks().collect_vec();
     assert!(!blocks.is_empty());
@@ -545,7 +545,8 @@ fn test_indexed_input_with_auto_delimiter() {
     let data = b"line1\n  continued\nline2\n}also continued\nline3";
     let stream = Stream::RandomAccess(Box::new(Cursor::new(data)));
     let indexer = Indexer::<LocalFileSystem>::new(1, PathBuf::new(), IndexerSettings::with_fs(LocalFileSystem));
-    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::Auto, &indexer).unwrap();
+    let input =
+        IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::PrettyCompatible, &indexer).unwrap();
 
     let blocks = input.into_blocks().collect_vec();
     assert!(!blocks.is_empty());
@@ -565,7 +566,7 @@ fn test_block_entry_empty() {
     let data = b"\n\n";
     let stream = Stream::RandomAccess(Box::new(Cursor::new(data)));
     let indexer = Indexer::<LocalFileSystem>::new(1, PathBuf::new(), IndexerSettings::with_fs(LocalFileSystem));
-    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::SmartNewLine, &indexer).unwrap();
+    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::NewLine, &indexer).unwrap();
 
     let blocks = input.into_blocks().collect_vec();
     assert!(!blocks.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,22 +232,21 @@ fn run() -> Result<()> {
         }
     }
 
-    let mut delimiter = Delimiter::default();
-    if let Some(d) = opt.delimiter {
-        delimiter = match d {
-            cli::Delimiter::Nul => Delimiter::Byte(0),
-            cli::Delimiter::Lf => Delimiter::Byte(b'\n'),
-            cli::Delimiter::Cr => Delimiter::Byte(b'\r'),
-            cli::Delimiter::Crlf => Delimiter::SmartNewLine,
-            cli::Delimiter::Auto => Delimiter::Auto,
-        };
-    } else {
-        match opt.input_format {
-            cli::InputFormat::Json => delimiter = Delimiter::Json,
-            cli::InputFormat::Logfmt => delimiter = Delimiter::SmartNewLine,
-            cli::InputFormat::Auto => {}
+    let delimiter = match opt.delimiter {
+        cli::Delimiter::Nul => Delimiter::Byte(0),
+        cli::Delimiter::Lf => Delimiter::Byte(b'\n'),
+        cli::Delimiter::Cr => Delimiter::Byte(b'\r'),
+        cli::Delimiter::Crlf => Delimiter::NewLine,
+        cli::Delimiter::Auto => {
+            if opt.allow_prefix || opt.input_format == cli::InputFormat::Logfmt {
+                Delimiter::NewLine
+            } else if opt.input_format == cli::InputFormat::Json {
+                Delimiter::Json
+            } else {
+                Delimiter::PrettyCompatible
+            }
         }
-    }
+    };
 
     let mut input_info = *opt.input_info;
     if input_info.contains(InputInfo::Auto) {

--- a/src/scanning/auto.rs
+++ b/src/scanning/auto.rs
@@ -2,13 +2,13 @@
 use std::ops::Range;
 
 // relative imports
-use super::{Delimit, Search, SmartNewLineSearcher};
+use super::{Delimit, NewLineSearcher, Search};
 
 #[derive(Clone)]
-pub struct AutoDelimiter;
+pub struct PrettyCompatibleDelimiter;
 
-impl Delimit for AutoDelimiter {
-    type Searcher = AutoDelimitSearcher;
+impl Delimit for PrettyCompatibleDelimiter {
+    type Searcher = PrettyCompatibleSearcher;
 
     #[inline]
     fn into_searcher(self) -> Self::Searcher {
@@ -18,13 +18,13 @@ impl Delimit for AutoDelimiter {
 
 /// Searches for a new line in a byte slice that can be either LF or CRLF
 /// surrounded by lines starting with non-whitespace characters.
-pub struct AutoDelimitSearcher;
+pub struct PrettyCompatibleSearcher;
 
-impl Search for AutoDelimitSearcher {
+impl Search for PrettyCompatibleSearcher {
     #[inline]
     fn search_r(&self, buf: &[u8], edge: bool) -> Option<Range<usize>> {
         let mut r = buf.len();
-        while let Some(range) = SmartNewLineSearcher.search_r(&buf[..r], edge) {
+        while let Some(range) = NewLineSearcher.search_r(&buf[..r], edge) {
             if edge && range.end == buf.len() {
                 return Some(range);
             }
@@ -42,7 +42,7 @@ impl Search for AutoDelimitSearcher {
     #[inline]
     fn search_l(&self, buf: &[u8], edge: bool) -> Option<Range<usize>> {
         let mut l = 0;
-        while let Some(range) = SmartNewLineSearcher.search_l(&buf[l..], edge) {
+        while let Some(range) = NewLineSearcher.search_l(&buf[l..], edge) {
             let range = (l + range.start)..(l + range.end);
 
             if edge && range.start == 0 {
@@ -61,7 +61,7 @@ impl Search for AutoDelimitSearcher {
 
     #[inline]
     fn partial_match_r(&self, buf: &[u8]) -> Option<usize> {
-        if let Some(m) = SmartNewLineSearcher.partial_match_r(buf) {
+        if let Some(m) = NewLineSearcher.partial_match_r(buf) {
             return Some(m);
         }
         if let Some(&b'\n') = buf.last() {
@@ -75,7 +75,7 @@ impl Search for AutoDelimitSearcher {
 
     #[inline]
     fn partial_match_l(&self, buf: &[u8]) -> Option<usize> {
-        SmartNewLineSearcher.partial_match_l(buf)
+        NewLineSearcher.partial_match_l(buf)
     }
 }
 

--- a/src/scanning/auto/tests.rs
+++ b/src/scanning/auto/tests.rs
@@ -16,7 +16,7 @@
 // 10. Exact boundary position handling
 // 11. Scanner simulation scenarios (multi-chunk processing)
 
-use super::AutoDelimitSearcher;
+use super::PrettyCompatibleSearcher;
 use crate::scanning::{Search, SearchExt};
 use rstest::rstest;
 use std::ops::Range;
@@ -32,7 +32,7 @@ fn test_auto_search_r_valid_delimiters(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_r(input, edge), expected);
 }
 
@@ -48,7 +48,7 @@ fn test_auto_search_r_skip_continuations(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_r(input, edge), expected);
 }
 
@@ -59,7 +59,7 @@ fn test_auto_search_r_skip_continuations(
 #[case(b"", false, None)]
 #[case(b"no_newline", false, None)]
 fn test_auto_search_r_edge_cases(#[case] input: &[u8], #[case] edge: bool, #[case] expected: Option<Range<usize>>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_r(input, edge), expected);
 }
 
@@ -72,7 +72,7 @@ fn test_auto_search_r_edge_mode_at_buffer_end(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_r(input, edge), expected);
 }
 
@@ -87,7 +87,7 @@ fn test_auto_search_l_valid_delimiters(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_l(input, edge), expected);
 }
 
@@ -103,7 +103,7 @@ fn test_auto_search_l_skip_continuations(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_l(input, edge), expected);
 }
 
@@ -115,7 +115,7 @@ fn test_auto_search_l_skip_continuations(
 #[case(b"", false, None)]
 #[case(b"no_newline", false, None)]
 fn test_auto_search_l_edge_cases(#[case] input: &[u8], #[case] edge: bool, #[case] expected: Option<Range<usize>>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_l(input, edge), expected);
 }
 
@@ -128,7 +128,7 @@ fn test_auto_search_l_edge_mode_at_buffer_start(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_l(input, edge), expected);
 }
 
@@ -143,7 +143,7 @@ fn test_auto_search_l_edge_mode_at_buffer_start(
 #[case(b"\r\n", Some(0))]
 #[case(b"\r", Some(0))]
 fn test_auto_partial_match_r_basic(#[case] input: &[u8], #[case] expected: Option<usize>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.partial_match_r(input), expected);
 }
 
@@ -153,7 +153,7 @@ fn test_auto_partial_match_r_basic(#[case] input: &[u8], #[case] expected: Optio
 #[case(b"a\n", Some(1))]
 #[case(b"abcdef", None)]
 fn test_auto_partial_match_r_positions(#[case] input: &[u8], #[case] expected: Option<usize>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let result = searcher.partial_match_r(input);
     assert_eq!(result, expected);
 
@@ -173,7 +173,7 @@ fn test_auto_partial_match_r_positions(#[case] input: &[u8], #[case] expected: O
 #[case(b"", None)]
 #[case(b"\n", Some(1))]
 fn test_auto_partial_match_l_basic(#[case] input: &[u8], #[case] expected: Option<usize>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.partial_match_l(input), expected);
 }
 
@@ -184,7 +184,7 @@ fn test_auto_partial_match_l_basic(#[case] input: &[u8], #[case] expected: Optio
 #[case(b"a\n\n\n", false, Some(1..2))]
 #[case(b"\n}\n}\n}", false, None)]
 fn test_auto_multiple_newlines(#[case] input: &[u8], #[case] edge: bool, #[case] expected: Option<Range<usize>>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_l(input, edge), expected);
 }
 
@@ -196,7 +196,7 @@ fn test_auto_multiple_newlines(#[case] input: &[u8], #[case] edge: bool, #[case]
 #[case(b"x\n\ty\nz", vec![&b"x\n\ty"[..], &b"z"[..]])]
 #[case(b"no_delim", vec![&b"no_delim"[..]])]
 fn test_auto_split_combinations(#[case] input: &[u8], #[case] expected: Vec<&[u8]>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let result: Vec<&[u8]> = searcher.split(input).collect();
     assert_eq!(result, expected);
 }
@@ -208,7 +208,7 @@ fn test_auto_split_combinations(#[case] input: &[u8], #[case] expected: Vec<&[u8
 #[case(b"line\n", b"}", b"line\n}")]
 #[case(b"line\n", b" next", b"line\n next")]
 fn test_auto_cross_boundary_scenarios(#[case] left: &[u8], #[case] right: &[u8], #[case] combined: &[u8]) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
 
     let partial = searcher.partial_match_r(left);
     assert!(partial.is_some(), "Should have partial match at boundary");
@@ -229,7 +229,7 @@ fn test_auto_cross_boundary_scenarios(#[case] left: &[u8], #[case] right: &[u8],
 #[case(b' ')]
 #[case(b'\t')]
 fn test_auto_all_continuation_chars_search_r(#[case] cont: u8) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let mut input = Vec::from(&b"line\n"[..]);
     input.push(cont);
 
@@ -242,7 +242,7 @@ fn test_auto_all_continuation_chars_search_r(#[case] cont: u8) {
 #[case(b' ')]
 #[case(b'\t')]
 fn test_auto_all_continuation_chars_search_l(#[case] cont: u8) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let mut input = Vec::from(&b"line\n"[..]);
     input.push(cont);
 
@@ -255,7 +255,7 @@ fn test_auto_all_continuation_chars_search_l(#[case] cont: u8) {
 #[case(b"a\nb\r\nc\nd", false)]
 #[case(b"a\r\nb\nc\r\nd", false)]
 fn test_auto_mixed_line_endings_search_r(#[case] input: &[u8], #[case] edge: bool) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let result = searcher.search_r(input, edge);
     assert!(result.is_some(), "Should handle mixed line endings");
 
@@ -268,7 +268,7 @@ fn test_auto_mixed_line_endings_search_r(#[case] input: &[u8], #[case] edge: boo
 #[case(b"a\nb\r\nc\nd", false)]
 #[case(b"a\r\nb\nc\r\nd", false)]
 fn test_auto_mixed_line_endings_search_l(#[case] input: &[u8], #[case] edge: bool) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let result = searcher.search_l(input, edge);
     assert!(result.is_some(), "Should handle mixed line endings");
 
@@ -283,7 +283,7 @@ fn test_auto_mixed_line_endings_search_l(#[case] input: &[u8], #[case] edge: boo
 #[case(b"a\n}\n}\n}b\nc", Some(8..9))]
 #[case(b"x\n \n\t\n}y\nz", Some(8..9))]
 fn test_auto_continuation_sequences_search_r(#[case] input: &[u8], #[case] expected: Option<Range<usize>>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_r(input, false), expected);
 }
 
@@ -292,7 +292,7 @@ fn test_auto_continuation_sequences_search_r(#[case] input: &[u8], #[case] expec
 #[case(b"a\n}\n}\n}b\nc", Some(8..9))]
 #[case(b"x\n \n\t\n}y\nz", Some(8..9))]
 fn test_auto_continuation_sequences_search_l(#[case] input: &[u8], #[case] expected: Option<Range<usize>>) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     assert_eq!(searcher.search_l(input, false), expected);
 }
 
@@ -301,7 +301,7 @@ fn test_auto_continuation_sequences_search_l(#[case] input: &[u8], #[case] expec
 #[case(1000)]
 #[case(10000)]
 fn test_auto_long_lines(#[case] length: usize) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let mut input = vec![b'x'; length];
     input.push(b'\n');
     input.push(b'y');
@@ -325,14 +325,14 @@ fn test_auto_exact_edge_boundaries_search_r(
     #[case] exp_start: usize,
     #[case] exp_end: usize,
 ) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
     let result = searcher.search_r(input, edge);
     assert_eq!(result, Some(exp_start..exp_end));
 }
 
 #[test]
 fn test_auto_exact_edge_boundaries_search_l() {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
 
     let result = searcher.search_l(b"\nx", true);
     assert_eq!(result, Some(0..1));
@@ -346,7 +346,7 @@ fn test_auto_exact_edge_boundaries_search_l() {
 #[case(b"line1\n", b"line2\n", b"line3\n")]
 #[case(b"a\n", b"b\n", b"c\n")]
 fn test_auto_scanner_simulation_no_extra_blocks(#[case] chunk1: &[u8], #[case] chunk2: &[u8], #[case] chunk3: &[u8]) {
-    let searcher = AutoDelimitSearcher;
+    let searcher = PrettyCompatibleSearcher;
 
     // Simulate scanner behavior across chunk boundaries
     // Chunk 1: ends with \n

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -89,7 +89,7 @@ fn test_only_delim() {
 
 #[test]
 fn test_only_delim_auto() {
-    let searcher = SmartNewLine.into_searcher();
+    let searcher = NewLine.into_searcher();
     let buf = b"\n";
     let mut iter = searcher.split(buf);
 
@@ -99,7 +99,7 @@ fn test_only_delim_auto() {
 
 #[test]
 fn test_delim_combo_auto() {
-    let searcher = SmartNewLine.into_searcher();
+    let searcher = NewLine.into_searcher();
     let buf = b"a\n\r\nb\naaaa\n\r\nbbbb\n";
     let mut iter = searcher.split(buf);
 
@@ -327,7 +327,7 @@ fn test_jumbo_0() {
 #[test]
 fn test_jumbo_smart_new_line() {
     let sf = Arc::new(SegmentBufFactory::new(3));
-    let scanner = Scanner::new(sf.clone(), SmartNewLine);
+    let scanner = Scanner::new(sf.clone(), NewLine);
     let mut data = std::io::Cursor::new(b"test\r\ntoken\r\nvery\r\nlarge\nx/");
     let tokens = scanner
         .items(&mut data)
@@ -349,7 +349,7 @@ fn test_jumbo_smart_new_line() {
 #[test]
 fn test_jumbo_smart_new_line_2() {
     let sf = Arc::new(SegmentBufFactory::new(3));
-    let scanner = Scanner::new(sf.clone(), SmartNewLine);
+    let scanner = Scanner::new(sf.clone(), NewLine);
     let mut data = std::io::Cursor::new(b"test token\r\neof\r\n");
     let tokens = scanner
         .items(&mut data)
@@ -407,7 +407,7 @@ fn test_substr_searcher_partial_match_l() {
 
 #[test]
 fn test_smart_newline_searcher_partial_match_l() {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
 
     // Buffer starting with \n
     let buf = b"\n";
@@ -453,7 +453,7 @@ fn test_smart_newline_search_l_edge_cases(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let result = searcher.search_l(buf, edge);
     assert_eq!(result, expected);
 }
@@ -472,7 +472,7 @@ fn test_smart_newline_search_l_multiple_newlines(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let result = searcher.search_l(buf, edge);
     assert_eq!(result, expected);
 }
@@ -487,7 +487,7 @@ fn test_smart_newline_search_l_multiple_newlines(
 #[case(b"first\nsecond\n", Some(12..13))] // case 7
 #[case(b"first\r\nsecond\r\n", Some(13..15))] // case 8
 fn test_smart_newline_search_r(#[case] buf: &[u8], #[case] expected: Option<Range<usize>>) {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let result = searcher.search_r(buf, false);
     assert_eq!(result, expected);
     let result = searcher.search_r(buf, true);
@@ -502,14 +502,14 @@ fn test_smart_newline_search_r(#[case] buf: &[u8], #[case] expected: Option<Rang
 #[case(b"test\n", None)] // case 5
 #[case(b"test\r\n", None)] // case 6
 fn test_smart_newline_partial_match_r(#[case] buf: &[u8], #[case] expected: Option<usize>) {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let result = searcher.partial_match_r(buf);
     assert_eq!(result, expected);
 }
 
 #[test]
 fn test_smart_newline_split_mixed_line_endings() {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let buf = b"line1\nline2\r\nline3\nline4\r\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"line1"[..], &b"line2"[..], &b"line3"[..], &b"line4"[..]]);
@@ -517,7 +517,7 @@ fn test_smart_newline_split_mixed_line_endings() {
 
 #[test]
 fn test_smart_newline_split_only_lf() {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let buf = b"a\nb\nc\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"a"[..], &b"b"[..], &b"c"[..]]);
@@ -525,7 +525,7 @@ fn test_smart_newline_split_only_lf() {
 
 #[test]
 fn test_smart_newline_split_only_crlf() {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let buf = b"a\r\nb\r\nc\r\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"a"[..], &b"b"[..], &b"c"[..]]);
@@ -533,7 +533,7 @@ fn test_smart_newline_split_only_crlf() {
 
 #[test]
 fn test_smart_newline_split_empty_lines() {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
     let buf = b"a\n\nb\r\n\r\nc\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"a"[..], &b""[..], &b"b"[..], &b""[..], &b"c"[..]]);
@@ -541,7 +541,7 @@ fn test_smart_newline_split_empty_lines() {
 
 #[test]
 fn test_smart_newline_search_l_edge_false_with_crlf() {
-    let searcher = SmartNewLineSearcher;
+    let searcher = NewLineSearcher;
 
     // When edge=false, search_l skips the first byte
     // This test verifies correct offset calculation for both LF and CRLF
@@ -615,18 +615,22 @@ fn test_delimiter_enum_conversions() {
         Delimiter::Str(s) => assert_eq!(&*s, "::"),
         _ => panic!("Expected Delimiter::Str"),
     }
+
+    // Test conversion from NewLine
+    let delimiter = Delimiter::from(NewLine);
+    assert_eq!(delimiter, Delimiter::NewLine);
 }
 
 #[test]
 fn test_delimiter_default() {
     let delimiter = Delimiter::default();
-    assert_eq!(delimiter, Delimiter::Auto);
+    assert_eq!(delimiter, Delimiter::PrettyCompatible);
 }
 
 #[test]
 fn test_auto_delimiter_with_mixed_newlines() {
-    use super::auto::AutoDelimitSearcher;
-    let searcher = AutoDelimitSearcher;
+    use super::auto::PrettyCompatibleSearcher;
+    let searcher = PrettyCompatibleSearcher;
 
     // Mix of LF and CRLF
     let buf = b"line1\nline2\r\nline3";
@@ -650,11 +654,11 @@ fn test_searcher_arc_delegation() {
 
 #[test]
 fn test_auto_delimiter_with_scanner() {
-    use super::auto::AutoDelimiter;
+    use super::auto::PrettyCompatibleDelimiter;
 
     // Test that AutoDelimiter works correctly with Scanner
     let sf = Arc::new(SegmentBufFactory::new(10));
-    let scanner = Scanner::new(sf.clone(), AutoDelimiter);
+    let scanner = Scanner::new(sf.clone(), PrettyCompatibleDelimiter);
 
     // Test case: buffer ends with LF
     let mut data = std::io::Cursor::new(b"test\nmore");
@@ -666,10 +670,10 @@ fn test_auto_delimiter_with_scanner() {
 
 #[test]
 fn test_partial_match_r_position_semantics() {
-    use super::SmartNewLineSearcher;
+    use super::NewLineSearcher;
 
-    // Verify SmartNewLineSearcher correctly returns positions
-    let searcher = SmartNewLineSearcher;
+    // Verify NewLineSearcher correctly returns positions
+    let searcher = NewLineSearcher;
 
     // Buffer ending with CR
     let buf = b"test\r";

--- a/src/testing/assets/fixtures/delimiter/combined.log
+++ b/src/testing/assets/fixtures/delimiter/combined.log
@@ -1,0 +1,14 @@
+{"ts":"2024-01-01T00:00:01Z","level":"info","msg":"jsonl entry"}
+ts=2024-01-01T00:00:02Z level=info msg="logfmt entry"
+prefix: {"ts":"2024-01-01T00:00:03Z","level":"info","msg":"prefixed entry"}
+ space: {"ts":"2024-01-01T00:00:04Z","level":"info","msg":"space-prefixed entry"}
+{
+  "ts": "2024-01-01T00:00:05Z",
+  "level": "info",
+  "msg": "pretty entry"
+}
+{
+"ts": "2024-01-01T00:00:06Z",
+"level": "info",
+"msg": "pretty-stripped entry"
+}


### PR DESCRIPTION
## Summary

Fix `--allow-prefix` not working with prefixes starting with whitespace unless `--delimiter crlf` was explicitly specified.

## Problem

Since v0.35.0, the default `auto` delimiter mode uses multiline-aware scanning to support pretty-formatted JSON log entries. This mode assumes that lines on the boundary of adjacent entries should not start with whitespace or closing braces. This optimization broke `--allow-prefix` functionality for prefixes starting with whitespace.

Additionally, since v0.35.0, `--delimiter auto` and omitting the `--delimiter` option behaved differently:
- Omitting `--delimiter` performed smart auto-selection based on `--input-format`
- Explicit `--delimiter auto` always used multiline-aware scanning regardless of other options

This inconsistency was confusing and caused issues when users explicitly specified `--delimiter auto` together with `--input-format logfmt` or `--allow-prefix`.

## Solution

When `--delimiter auto` is specified (or `--delimiter` is omitted, which now defaults to `auto`), the delimiter selection now considers other options:

- If `--allow-prefix` is used → uses newline-based delimiter (`crlf`)
- If `--input-format logfmt` is used → uses newline-based delimiter (`crlf`)
- If `--input-format json` is used → uses JSON boundary delimiter (for multiline or pretty-formatted JSON)
- Otherwise → uses multiline-aware auto delimiter

This restores pre-0.35.0 behavior and makes `--delimiter auto` and omitting `--delimiter` behave identically.

## Behavior Changes

| Options | Before (0.35.0 .. 0.35.2) | After (0.35.3+) |
|---------|-----------------|-------|
| `--allow-prefix` | Uses multiline-aware delimiter (breaks whitespace prefixes) | Uses newline-based delimiter |
| `--delimiter auto --allow-prefix` | Uses multiline-aware delimiter | Uses newline-based delimiter |
| `--delimiter auto --input-format logfmt` | Uses multiline-aware delimiter | Uses newline-based delimiter |
| `--input-format logfmt` (no --delimiter) | Uses newline-based delimiter | Uses newline-based delimiter (unchanged) |
| `--input-format json` | Uses JSON boundary delimiter | Uses JSON boundary delimiter (unchanged) |

## Notes

- For parsing multiline JSON content that may not be properly pretty-printed, use `--input-format json`
- `--allow-prefix` is not compatible with `--input-format json` (multiline JSON entries cannot have line prefixes)
- Logfmt entries are single-line by definition, so multiline-aware scanning is not needed