### PR TITLE
fix: strip whitespace around json entries in raw output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.35.3-alpha.5"
+version = "0.35.3-alpha.6"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.3-alpha.5"
+version = "0.35.3-alpha.6"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/src/model.rs
+++ b/src/model.rs
@@ -1013,7 +1013,10 @@ impl RawRecordParser {
             Some(InputFormat::Json) => RawRecordStream::Json(RawRecordJsonStream {
                 prefix,
                 xn,
-                delegate: StreamDeserializerWithOffsets(json::Deserializer::from_slice(data).into_iter::<RawRecord>()),
+                delegate: StreamDeserializerWithOffsets {
+                    inner: json::Deserializer::from_slice(data).into_iter::<RawRecord>(),
+                    source: data,
+                },
             }),
             Some(InputFormat::Logfmt) => RawRecordStream::Logfmt(RawRecordLogfmtStream {
                 chunk,


### PR DESCRIPTION
## Summary

Fix incorrect output in raw mode when processing JSON input with whitespace between entries.

## Problem

When using raw output mode (`-r` / `--raw`) with JSON input that has whitespace (newlines, spaces) between entries, the leading whitespace could be incorrectly included at the beginning of each output entry.

## Fix

The byte range for each JSON entry now correctly excludes leading whitespace, producing clean output without unwanted whitespace prefixes.