### PR TITLE
feat(cli): add newline delimiter option and fix crlf behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.0-alpha.3"
+version = "0.36.0-alpha.4"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.0-alpha.3"
+version = "0.36.0-alpha.4"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ Input Options:
       --input-format <FORMAT>       Input format [env: HL_INPUT_FORMAT=] [default: auto] [possible values: auto, json, logfmt]
       --unix-timestamp-unit <UNIT>  Unix timestamp unit [env: HL_UNIX_TIMESTAMP_UNIT=] [default: auto] [possible values: auto, s, ms, us, ns]
       --allow-prefix                Allow non-JSON prefixes before JSON log entries [env: HL_ALLOW_PREFIX=]
-      --delimiter <DELIMITER>       Log entry delimiter [env: HL_DELIMITER=] [default: auto] [possible values: auto, cr, lf, crlf, nul]
+      --delimiter <DELIMITER>       Log entry delimiter [env: HL_DELIMITER=] [default: auto] [possible values: auto, cr, lf, crlf, newline, nul]
 
 Advanced Options:
       --interrupt-ignore-count <N>  Number of interrupts to ignore, i.e. Ctrl-C (SIGINT) [env: HL_INTERRUPT_IGNORE_COUNT=] [default: 3]

--- a/build/ci/coverage.sh
+++ b/build/ci/coverage.sh
@@ -76,15 +76,19 @@ function test() {
     $hl $fixture | check_hash "81e53d5944f93cfc5f26f9eca2c0a4cd99ec7ae48cfccf6f92011b66c6aa584d"
     # --delimiter auto: same as default
     $hl $fixture --delimiter auto | check_hash "81e53d5944f93cfc5f26f9eca2c0a4cd99ec7ae48cfccf6f92011b66c6aa584d"
-    # --delimiter crlf: parses jsonl, logfmt; shows prefixed, pretty, pretty-stripped raw
-    $hl $fixture --delimiter crlf | check_hash "1776b8f301b8809374bdb6fad936c5649f52d2a29c230c13db93db7b86a79e93"
+    # --delimiter crlf: parses first jsonl entry only; everything else is raw
+    $hl $fixture --delimiter crlf | check_hash "4fbecc426cb22b575ce64146a5229dde3923051366f4b3e6ffd24b2205ea6c18"
+    # --delimiter newline: parses jsonl, logfmt; shows prefixed, pretty, pretty-stripped raw
+    $hl $fixture --delimiter newline | check_hash "1776b8f301b8809374bdb6fad936c5649f52d2a29c230c13db93db7b86a79e93"
 
     # --input-format json: parses only json entries (jsonl, pretty, pretty-stripped)
     $hl $fixture --input-format json | check_hash "32250d3814dd03f2c5692b31daa73e5273c80914a0c1935acc318ceeb16e9401"
     # --input-format json --delimiter auto: same as above
     $hl $fixture --input-format json --delimiter auto | check_hash "32250d3814dd03f2c5692b31daa73e5273c80914a0c1935acc318ceeb16e9401"
-    # --input-format json --delimiter crlf: parses only jsonl (single-line json)
+    # --input-format json --delimiter crlf: shows first jsonl entry only
     $hl $fixture --input-format json --delimiter crlf | check_hash "0185e71755887aff184accfd23a8d3778d7d849d1b10a8ac7f0d828ddcbb8e80"
+    # --input-format json --delimiter newline: shows first jsonl entry only
+    $hl $fixture --input-format json --delimiter newline | check_hash "0185e71755887aff184accfd23a8d3778d7d849d1b10a8ac7f0d828ddcbb8e80"
     # --input-format json --allow-prefix: parses jsonl and prefixed json entries
     $hl $fixture --input-format json --allow-prefix | check_hash "f6267579b4e3c4233af9f8dbd09110d34a5fc7556378ae134da3a2959e892e9d"
 
@@ -92,8 +96,10 @@ function test() {
     $hl $fixture --input-format logfmt | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
     # --input-format logfmt --delimiter auto: same as above
     $hl $fixture --input-format logfmt --delimiter auto | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
-    # --input-format logfmt --delimiter crlf: same as above
-    $hl $fixture --input-format logfmt --delimiter crlf | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
+    # --input-format logfmt --delimiter crlf: shows nothing
+    $hl $fixture --input-format logfmt --delimiter crlf | check_hash "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    # --input-format logfmt --delimiter newline: same as 'auto' above
+    $hl $fixture --input-format logfmt --delimiter newline | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
     # --input-format logfmt --allow-prefix: same as above
     $hl $fixture --input-format logfmt --allow-prefix | check_hash "604d0912654c2375a9487234de91b3204c2f70de3652e175596d7028f94fb3d1"
 
@@ -101,8 +107,10 @@ function test() {
     $hl $fixture --allow-prefix | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
     # --allow-prefix --delimiter auto: same as above
     $hl $fixture --allow-prefix --delimiter auto | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
-    # --allow-prefix --delimiter crlf: same as above
-    $hl $fixture --allow-prefix --delimiter crlf | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
+    # --allow-prefix --delimiter crlf: parses first jsonl entry only; everything else is raw
+    $hl $fixture --allow-prefix --delimiter crlf | check_hash "4fbecc426cb22b575ce64146a5229dde3923051366f4b3e6ffd24b2205ea6c18"
+    # --allow-prefix --delimiter newline: same as 'auto' above
+    $hl $fixture --allow-prefix --delimiter newline | check_hash "9e56c27e1a2389eec5dfd37ea9e13310454686ce706e7a247bde66803bf1c17c"
 
     # Special delimiters: single test each
     $hl $fixture --delimiter lf | check_hash "1776b8f301b8809374bdb6fad936c5649f52d2a29c230c13db93db7b86a79e93"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -429,7 +429,8 @@ pub struct Opt {
     /// • <c>auto</>: Auto-detect delimiter (default)
     /// • <c>cr</>: Carriage return (\r)
     /// • <c>lf</>: Line feed (\n)
-    /// • <c>crlf</>: Carriage return + line feed (\r\n)
+    /// • <c>crlf</>: Carriage return followed by line feed (\r\n)
+    /// • <c>newline</>: Either lf or crlf, whichever comes first
     /// • <c>nul</>: Null character (\0)
     #[arg(long, env = "HL_DELIMITER", default_value = "auto", overrides_with = "delimiter", help_heading = heading::INPUT)]
     pub delimiter: Delimiter,
@@ -591,6 +592,7 @@ pub enum Delimiter {
     Cr,
     Lf,
     Crlf,
+    Newline,
     Nul,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,16 +236,25 @@ fn run() -> Result<()> {
         cli::Delimiter::Nul => Delimiter::Byte(0),
         cli::Delimiter::Lf => Delimiter::Byte(b'\n'),
         cli::Delimiter::Cr => Delimiter::Byte(b'\r'),
-        cli::Delimiter::Crlf => Delimiter::Newline,
-        cli::Delimiter::Auto => {
-            if opt.allow_prefix || opt.input_format == cli::InputFormat::Logfmt {
-                Delimiter::Newline
-            } else if opt.input_format == cli::InputFormat::Json {
-                Delimiter::Json
-            } else {
-                Delimiter::PrettyCompatible
+        cli::Delimiter::Crlf => Delimiter::Str("\r\n".into()),
+        cli::Delimiter::Newline => Delimiter::Newline,
+        cli::Delimiter::Auto => match opt.input_format {
+            cli::InputFormat::Auto => {
+                if opt.allow_prefix {
+                    Delimiter::Newline
+                } else {
+                    Delimiter::PrettyCompatible
+                }
             }
-        }
+            cli::InputFormat::Logfmt => Delimiter::Newline,
+            cli::InputFormat::Json => {
+                if opt.allow_prefix {
+                    Delimiter::Newline
+                } else {
+                    Delimiter::Json
+                }
+            }
+        },
     };
 
     let mut input_info = *opt.input_info;


### PR DESCRIPTION
## Summary

Add a new `newline` delimiter option and fix the incorrect behavior of the `crlf` option.

## Changes

- Add new `--delimiter=newline` option that automatically detects and matches either LF (`\n`) or CRLF (`\r\n`) line endings, whichever comes first
- Fix `--delimiter=crlf` to correctly match only the literal CRLF sequence (`\r\n`) instead of performing automatic newline detection
- Update documentation and help text to reflect the new option

## ⚠️ Breaking Change

The `--delimiter=crlf` option now strictly matches the `\r\n` sequence instead of detecting both LF and CRLF.

### Migration

If you were using `--delimiter=crlf` and relied on it matching both `\n` and `\r\n`:

- Replace `--delimiter=crlf` with `--delimiter=newline`
- Or update the `HL_DELIMITER` environment variable from `crlf` to `newline`

## Delimiter Options

| Value | Description |
|-------|-------------|
| `auto` | Auto-detect delimiter (default) |
| `cr` | Carriage return (`\r`) |
| `lf` | Line feed (`\n`) |
| `crlf` | Carriage return followed by line feed (`\r\n`) |
| `newline` | Either `lf` or `crlf`, whichever comes first |
| `nul` | Null character (`\0`) |