### PR TITLE
refactor: rename NewLine to Newline for consistent naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.0-alpha.2"
+version = "0.36.0-alpha.3"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.0-alpha.2"
+version = "0.36.0-alpha.3"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/benches/bench/ws/hl/delimiter.rs
+++ b/benches/bench/ws/hl/delimiter.rs
@@ -32,13 +32,13 @@ pub(super) fn bench(c: &mut Criterion) {
         (
             "s1:new-line:lf:e",
             Vec::from(samples::log::elk01::JSON),
-            Delimiter::NewLine,
+            Delimiter::Newline,
             BatchSize::NumIterations(8192),
         ),
         (
             "s1:new-line:lf:s",
             rotated(samples::log::elk01::JSON, 1),
-            Delimiter::NewLine,
+            Delimiter::Newline,
             BatchSize::NumIterations(8192),
         ),
     ];

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ use crate::{
     input::{BlockEntry, Input, InputHolder, InputReference},
     model::{Filter, Parser, ParserSettings, RawRecord, Record, RecordFilter, RecordWithSourceConstructor},
     query::Query,
-    scanning::{BufFactory, Delimit, Delimiter, NewLine, Scanner, SearchExt, Segment, SegmentBuf, SegmentBufFactory},
+    scanning::{BufFactory, Delimit, Delimiter, Newline, Scanner, SearchExt, Segment, SegmentBuf, SegmentBufFactory},
     settings::{AsciiMode, ExpansionMode, FieldShowOption, Fields, Formatting, InputInfo, ResolvedPunctuation},
     theme::{Element, StylingPush, SyncIndicatorPack, Theme},
     timezone::Tz,
@@ -1019,7 +1019,7 @@ impl<'a, Formatter: RecordWithSourceFormatter, Filter: RecordFilter> SegmentProc
                         buf.extend(prefix.as_bytes());
                     } else {
                         let mut first = true;
-                        for line in NewLine.into_searcher().split(ar.prefix) {
+                        for line in Newline.into_searcher().split(ar.prefix) {
                             if !first {
                                 buf.push(b'\n');
                             }
@@ -1046,7 +1046,7 @@ impl<'a, Formatter: RecordWithSourceFormatter, Filter: RecordFilter> SegmentProc
             if !remainder.is_empty() && self.show_unparsed() {
                 if !parsed_some || produced_some {
                     let mut should_prefix = !parsed_some;
-                    for line in NewLine.into_searcher().split(remainder) {
+                    for line in Newline.into_searcher().split(remainder) {
                         if should_prefix {
                             buf.extend(prefix.as_bytes());
                         }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -20,7 +20,7 @@ use crate::{
     filtering::IncludeExcludeSetting,
     fmtx::{OptimizedBuf, Push, aligned_left},
     model::{self, Caller, Level, RawValue},
-    scanning::{Delimit, NewLine, SearchExt},
+    scanning::{Delimit, Newline, SearchExt},
     settings::{self, AsciiMode, ExpansionMode, Formatting, ResolvedPunctuation},
     syntax::*,
     theme::{Element, Styler, StylingPush, Theme},
@@ -146,7 +146,7 @@ impl RecordWithSourceFormatter for RawRecordFormatter {
     #[inline(always)]
     fn format_record(&self, buf: &mut Buf, prefix: Range<usize>, rec: model::RecordWithSource) {
         let mut first = true;
-        for line in NewLine.into_searcher().split(rec.source) {
+        for line in Newline.into_searcher().split(rec.source) {
             if !first {
                 buf.push(b'\n');
                 buf.extend_from_within(prefix.clone());
@@ -1551,7 +1551,7 @@ pub mod string {
                     | Flag::Backtick
                     | Flag::Space
                     | Flag::Tab
-                    | Flag::NewLine
+                    | Flag::Newline
                     | Flag::EqualSign
             );
 
@@ -1565,25 +1565,25 @@ pub mod string {
                 return Ok(FormatResult::Ok(None));
             }
 
-            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'"');
                 buf.push(b'"');
                 buf[begin..].rotate_right(1);
                 return Ok(FormatResult::Ok(None));
             }
 
-            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'\'');
                 buf.push(b'\'');
                 buf[begin..].rotate_right(1);
                 return Ok(FormatResult::Ok(None));
             }
 
-            const WS: Mask = mask!(Flag::NewLine | Flag::Tab | Flag::Space);
+            const WS: Mask = mask!(Flag::Newline | Flag::Tab | Flag::Space);
 
             let has_control = mask.contains(Flag::Control);
             let has_backtick = mask.contains(Flag::Backtick);
-            let has_extended_space = mask.intersects(Flag::NewLine | Flag::Tab);
+            let has_extended_space = mask.intersects(Flag::Newline | Flag::Tab);
             let has_non_whitespace = mask.intersects(!WS);
 
             if !has_control && has_non_whitespace {
@@ -1673,7 +1673,7 @@ pub mod string {
             let analysis = buf[begin..].analyze();
             let mask = analysis.chars;
 
-            const NOT_PLAIN: Mask = mask!(Flag::EqualSign | Flag::Control | Flag::NewLine | Flag::Backslash);
+            const NOT_PLAIN: Mask = mask!(Flag::EqualSign | Flag::Control | Flag::Newline | Flag::Backslash);
 
             if !mask.intersects(NOT_PLAIN)
                 && !matches!(buf.get(begin), Some(b'"' | b'\'' | b'`'))
@@ -1682,21 +1682,21 @@ pub mod string {
                 return Ok(FormatResult::Ok(Some(analysis)));
             }
 
-            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'"');
                 buf.push(b'"');
                 buf[begin..].rotate_right(1);
                 return Ok(FormatResult::Ok(Some(analysis)));
             }
 
-            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'\'');
                 buf.push(b'\'');
                 buf[begin..].rotate_right(1);
                 return Ok(FormatResult::Ok(Some(analysis)));
             }
 
-            const XS: Mask = mask!(Flag::NewLine);
+            const XS: Mask = mask!(Flag::Newline);
             let has_control = mask.contains(Flag::Control);
             let has_backtick = mask.contains(Flag::Backtick);
             let has_newline = mask.intersects(XS);
@@ -1743,15 +1743,15 @@ pub mod string {
             let analysis = buf[begin + 1..].analyze();
             let mask = analysis.chars;
 
-            const XS: Mask = mask!(Flag::NewLine);
+            const XS: Mask = mask!(Flag::Newline);
             let has_newline = mask.intersects(XS);
 
-            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'"');
                 return Ok(FormatResult::Ok(None));
             }
 
-            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf[begin] = b'\'';
                 buf.push(b'\'');
                 return Ok(FormatResult::Ok(None));
@@ -1805,7 +1805,7 @@ pub mod string {
             let analysis = buf[begin..].analyze();
             let mask = analysis.chars;
 
-            const XS: Mask = mask!(Flag::NewLine);
+            const XS: Mask = mask!(Flag::Newline);
             if mask.intersects(XS) && matches!(options.xsa, ExtendedSpaceAction::Abort) {
                 buf.truncate(begin);
                 return Ok(FormatResult::Aborted);
@@ -1823,7 +1823,7 @@ pub mod string {
                 return Ok(FormatResult::Ok(Some(analysis)));
             }
 
-            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::DoubleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'"');
                 buf.push(b'"');
                 buf[begin..].rotate_right(1);
@@ -1831,7 +1831,7 @@ pub mod string {
                 return Ok(FormatResult::Ok(Some(analysis)));
             }
 
-            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::NewLine | Flag::Backslash) {
+            if !mask.intersects(Flag::SingleQuote | Flag::Control | Flag::Tab | Flag::Newline | Flag::Backslash) {
                 buf.push(b'\'');
                 buf.push(b'\'');
                 buf[begin..].rotate_right(1);
@@ -1946,7 +1946,7 @@ pub mod string {
         const BT: Mask = mask!(Flag::Backtick); // 0x60
         const SP: Mask = mask!(Flag::Space); // 0x20
         const TB: Mask = mask!(Flag::Tab); // 0x09
-        const NL: Mask = mask!(Flag::NewLine); // 0x0A, 0x0D
+        const NL: Mask = mask!(Flag::Newline); // 0x0A, 0x0D
         const EQ: Mask = mask!(Flag::EqualSign); // 0x3D
         const HY: Mask = mask!(Flag::Minus); // Hyphen, 0x2D
         const DO: Mask = mask!(Flag::Dot); // Dot, 0x2E
@@ -1988,7 +1988,7 @@ pub mod string {
         Backtick,
         Space,
         Tab,
-        NewLine,
+        Newline,
         EqualSign,
         Digit,
         Minus,

--- a/src/index/tests.rs
+++ b/src/index/tests.rs
@@ -448,7 +448,7 @@ fn test_indexer_chronology_with_unsorted_entries() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::NewLine,
+            delimiter: Delimiter::Newline,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -483,7 +483,7 @@ fn test_indexer_with_empty_entries() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::NewLine,
+            delimiter: Delimiter::Newline,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -562,7 +562,7 @@ fn test_indexer_with_mixed_valid_invalid_entries() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(4096u32).into(),
-            delimiter: Delimiter::NewLine,
+            delimiter: Delimiter::Newline,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -595,7 +595,7 @@ fn test_indexer_large_entries_across_blocks() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(1024u32).into(),
-            delimiter: Delimiter::NewLine,
+            delimiter: Delimiter::Newline,
             ..IndexerSettings::with_fs(fs)
         },
     );
@@ -635,7 +635,7 @@ fn test_chronology_bitmap_structure() {
         PathBuf::from("/tmp/cache"),
         IndexerSettings {
             buffer_size: nonzero!(16384u32).into(),
-            delimiter: Delimiter::NewLine,
+            delimiter: Delimiter::Newline,
             ..IndexerSettings::with_fs(fs)
         },
     );

--- a/src/input/tests.rs
+++ b/src/input/tests.rs
@@ -52,7 +52,7 @@ fn test_input() {
 
 #[test]
 fn test_input_tail() {
-    let input = Input::stdin().unwrap().tail(1, Delimiter::NewLine).unwrap();
+    let input = Input::stdin().unwrap().tail(1, Delimiter::Newline).unwrap();
     assert!(matches!(input.stream, Stream::Sequential(_)));
 
     for &(filename, requested, expected) in &[
@@ -63,7 +63,7 @@ fn test_input_tail() {
     ] {
         let input = Input::open(&PathBuf::from(filename))
             .unwrap()
-            .tail(requested, Delimiter::NewLine)
+            .tail(requested, Delimiter::Newline)
             .unwrap();
         let mut buf = Vec::new();
         let n = input.stream.into_sequential().read_to_end(&mut buf).unwrap();
@@ -197,7 +197,7 @@ fn test_indexed_input_file_random_access() {
                 ..IndexerSettings::with_fs(fs.clone())
             },
         );
-        let input = IndexedInput::open(&path, &indexer, Delimiter::NewLine).unwrap();
+        let input = IndexedInput::open(&path, &indexer, Delimiter::Newline).unwrap();
         let mut blocks = input.into_blocks().sorted().collect_vec();
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0].entries_valid(), 1);
@@ -375,7 +375,7 @@ fn test_input_tail_ending_with_delimiter() {
     let input = Input::new(reference, stream);
 
     // Request last 1 entry
-    let input = input.tail(1, Delimiter::NewLine).unwrap();
+    let input = input.tail(1, Delimiter::Newline).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -410,7 +410,7 @@ fn test_input_tail_more_than_available() {
     let input = Input::new(reference, stream);
 
     // Request more entries than available
-    let input = input.tail(10, Delimiter::NewLine).unwrap();
+    let input = input.tail(10, Delimiter::Newline).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -428,7 +428,7 @@ fn test_input_tail_with_crlf() {
     let input = Input::new(reference, stream);
 
     // Request last 2 entries
-    let input = input.tail(2, Delimiter::NewLine).unwrap();
+    let input = input.tail(2, Delimiter::Newline).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -445,7 +445,7 @@ fn test_input_tail_partial_match_handling() {
     let reference = InputReference::Stdin;
     let input = Input::new(reference, stream);
 
-    let input = input.tail(3, Delimiter::NewLine).unwrap();
+    let input = input.tail(3, Delimiter::Newline).unwrap();
     let mut buf = Vec::new();
     input.stream.into_sequential().read_to_end(&mut buf).unwrap();
 
@@ -507,7 +507,7 @@ fn test_block_entry_methods() {
     let data = include_bytes!("testdata/two_messages.jsonl");
     let stream = Stream::RandomAccess(Box::new(Cursor::new(data)));
     let indexer = Indexer::<LocalFileSystem>::new(1, PathBuf::new(), IndexerSettings::with_fs(LocalFileSystem));
-    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::NewLine, &indexer).unwrap();
+    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::Newline, &indexer).unwrap();
 
     let blocks = input.into_blocks().collect_vec();
     assert!(!blocks.is_empty());
@@ -566,7 +566,7 @@ fn test_block_entry_empty() {
     let data = b"\n\n";
     let stream = Stream::RandomAccess(Box::new(Cursor::new(data)));
     let indexer = Indexer::<LocalFileSystem>::new(1, PathBuf::new(), IndexerSettings::with_fs(LocalFileSystem));
-    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::NewLine, &indexer).unwrap();
+    let input = IndexedInput::from_stream(InputReference::Stdin, stream, Delimiter::Newline, &indexer).unwrap();
 
     let blocks = input.into_blocks().collect_vec();
     assert!(!blocks.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,10 +236,10 @@ fn run() -> Result<()> {
         cli::Delimiter::Nul => Delimiter::Byte(0),
         cli::Delimiter::Lf => Delimiter::Byte(b'\n'),
         cli::Delimiter::Cr => Delimiter::Byte(b'\r'),
-        cli::Delimiter::Crlf => Delimiter::NewLine,
+        cli::Delimiter::Crlf => Delimiter::Newline,
         cli::Delimiter::Auto => {
             if opt.allow_prefix || opt.input_format == cli::InputFormat::Logfmt {
-                Delimiter::NewLine
+                Delimiter::Newline
             } else if opt.input_format == cli::InputFormat::Json {
                 Delimiter::Json
             } else {

--- a/src/scanning.rs
+++ b/src/scanning.rs
@@ -54,7 +54,7 @@ pub enum Delimiter {
     Bytes(Arc<[u8]>),
     Char(char),
     Str(Arc<str>),
-    NewLine,
+    Newline,
     Json,
 }
 
@@ -114,10 +114,10 @@ impl From<String> for Delimiter {
     }
 }
 
-impl From<NewLine> for Delimiter {
+impl From<Newline> for Delimiter {
     #[inline]
-    fn from(_: NewLine) -> Self {
-        Self::NewLine
+    fn from(_: Newline) -> Self {
+        Self::Newline
     }
 }
 
@@ -131,7 +131,7 @@ impl Delimit for Delimiter {
             Self::Bytes(b) => Arc::new(b.into_searcher()),
             Self::Char(c) => Arc::new(c.into_searcher()),
             Self::Str(s) => Arc::new(s.into_searcher()),
-            Self::NewLine => Arc::new(NewLine.into_searcher()),
+            Self::Newline => Arc::new(Newline.into_searcher()),
             Self::Json => Arc::new(JsonDelimiter.into_searcher()),
             Self::PrettyCompatible => Arc::new(PrettyCompatibleDelimiter.into_searcher()),
         }
@@ -243,10 +243,10 @@ impl Delimit for &Delimiter {
 
 /// Defines a smart new line delimiter that can be either LF or CRLF.
 #[derive(Clone)]
-pub struct NewLine;
+pub struct Newline;
 
-impl Delimit for NewLine {
-    type Searcher = NewLineSearcher;
+impl Delimit for Newline {
+    type Searcher = NewlineSearcher;
 
     #[inline(always)]
     fn into_searcher(self) -> Self::Searcher {
@@ -504,9 +504,9 @@ where
 // ---
 
 /// Searches for a new line in a byte slice that can be either LF or CRLF.
-pub struct NewLineSearcher;
+pub struct NewlineSearcher;
 
-impl Search for NewLineSearcher {
+impl Search for NewlineSearcher {
     #[inline]
     fn search_r(&self, buf: &[u8], _edge: bool) -> Option<Range<usize>> {
         memrchr(b'\n', buf).map(|i| {

--- a/src/scanning/auto.rs
+++ b/src/scanning/auto.rs
@@ -2,7 +2,7 @@
 use std::ops::Range;
 
 // relative imports
-use super::{Delimit, NewLineSearcher, Search};
+use super::{Delimit, NewlineSearcher, Search};
 
 #[derive(Clone)]
 pub struct PrettyCompatibleDelimiter;
@@ -24,7 +24,7 @@ impl Search for PrettyCompatibleSearcher {
     #[inline]
     fn search_r(&self, buf: &[u8], edge: bool) -> Option<Range<usize>> {
         let mut r = buf.len();
-        while let Some(range) = NewLineSearcher.search_r(&buf[..r], edge) {
+        while let Some(range) = NewlineSearcher.search_r(&buf[..r], edge) {
             if edge && range.end == buf.len() {
                 return Some(range);
             }
@@ -42,7 +42,7 @@ impl Search for PrettyCompatibleSearcher {
     #[inline]
     fn search_l(&self, buf: &[u8], edge: bool) -> Option<Range<usize>> {
         let mut l = 0;
-        while let Some(range) = NewLineSearcher.search_l(&buf[l..], edge) {
+        while let Some(range) = NewlineSearcher.search_l(&buf[l..], edge) {
             let range = (l + range.start)..(l + range.end);
 
             if edge && range.start == 0 {
@@ -61,7 +61,7 @@ impl Search for PrettyCompatibleSearcher {
 
     #[inline]
     fn partial_match_r(&self, buf: &[u8]) -> Option<usize> {
-        if let Some(m) = NewLineSearcher.partial_match_r(buf) {
+        if let Some(m) = NewlineSearcher.partial_match_r(buf) {
             return Some(m);
         }
         if let Some(&b'\n') = buf.last() {
@@ -75,7 +75,7 @@ impl Search for PrettyCompatibleSearcher {
 
     #[inline]
     fn partial_match_l(&self, buf: &[u8]) -> Option<usize> {
-        NewLineSearcher.partial_match_l(buf)
+        NewlineSearcher.partial_match_l(buf)
     }
 }
 

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -89,7 +89,7 @@ fn test_only_delim() {
 
 #[test]
 fn test_only_delim_auto() {
-    let searcher = NewLine.into_searcher();
+    let searcher = Newline.into_searcher();
     let buf = b"\n";
     let mut iter = searcher.split(buf);
 
@@ -99,7 +99,7 @@ fn test_only_delim_auto() {
 
 #[test]
 fn test_delim_combo_auto() {
-    let searcher = NewLine.into_searcher();
+    let searcher = Newline.into_searcher();
     let buf = b"a\n\r\nb\naaaa\n\r\nbbbb\n";
     let mut iter = searcher.split(buf);
 
@@ -327,7 +327,7 @@ fn test_jumbo_0() {
 #[test]
 fn test_jumbo_smart_new_line() {
     let sf = Arc::new(SegmentBufFactory::new(3));
-    let scanner = Scanner::new(sf.clone(), NewLine);
+    let scanner = Scanner::new(sf.clone(), Newline);
     let mut data = std::io::Cursor::new(b"test\r\ntoken\r\nvery\r\nlarge\nx/");
     let tokens = scanner
         .items(&mut data)
@@ -349,7 +349,7 @@ fn test_jumbo_smart_new_line() {
 #[test]
 fn test_jumbo_smart_new_line_2() {
     let sf = Arc::new(SegmentBufFactory::new(3));
-    let scanner = Scanner::new(sf.clone(), NewLine);
+    let scanner = Scanner::new(sf.clone(), Newline);
     let mut data = std::io::Cursor::new(b"test token\r\neof\r\n");
     let tokens = scanner
         .items(&mut data)
@@ -407,7 +407,7 @@ fn test_substr_searcher_partial_match_l() {
 
 #[test]
 fn test_smart_newline_searcher_partial_match_l() {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
 
     // Buffer starting with \n
     let buf = b"\n";
@@ -453,7 +453,7 @@ fn test_smart_newline_search_l_edge_cases(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let result = searcher.search_l(buf, edge);
     assert_eq!(result, expected);
 }
@@ -472,7 +472,7 @@ fn test_smart_newline_search_l_multiple_newlines(
     #[case] edge: bool,
     #[case] expected: Option<Range<usize>>,
 ) {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let result = searcher.search_l(buf, edge);
     assert_eq!(result, expected);
 }
@@ -487,7 +487,7 @@ fn test_smart_newline_search_l_multiple_newlines(
 #[case(b"first\nsecond\n", Some(12..13))] // case 7
 #[case(b"first\r\nsecond\r\n", Some(13..15))] // case 8
 fn test_smart_newline_search_r(#[case] buf: &[u8], #[case] expected: Option<Range<usize>>) {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let result = searcher.search_r(buf, false);
     assert_eq!(result, expected);
     let result = searcher.search_r(buf, true);
@@ -502,14 +502,14 @@ fn test_smart_newline_search_r(#[case] buf: &[u8], #[case] expected: Option<Rang
 #[case(b"test\n", None)] // case 5
 #[case(b"test\r\n", None)] // case 6
 fn test_smart_newline_partial_match_r(#[case] buf: &[u8], #[case] expected: Option<usize>) {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let result = searcher.partial_match_r(buf);
     assert_eq!(result, expected);
 }
 
 #[test]
 fn test_smart_newline_split_mixed_line_endings() {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let buf = b"line1\nline2\r\nline3\nline4\r\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"line1"[..], &b"line2"[..], &b"line3"[..], &b"line4"[..]]);
@@ -517,7 +517,7 @@ fn test_smart_newline_split_mixed_line_endings() {
 
 #[test]
 fn test_smart_newline_split_only_lf() {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let buf = b"a\nb\nc\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"a"[..], &b"b"[..], &b"c"[..]]);
@@ -525,7 +525,7 @@ fn test_smart_newline_split_only_lf() {
 
 #[test]
 fn test_smart_newline_split_only_crlf() {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let buf = b"a\r\nb\r\nc\r\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"a"[..], &b"b"[..], &b"c"[..]]);
@@ -533,7 +533,7 @@ fn test_smart_newline_split_only_crlf() {
 
 #[test]
 fn test_smart_newline_split_empty_lines() {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
     let buf = b"a\n\nb\r\n\r\nc\n";
     let parts: Vec<_> = searcher.split(buf).collect();
     assert_eq!(parts, vec![&b"a"[..], &b""[..], &b"b"[..], &b""[..], &b"c"[..]]);
@@ -541,7 +541,7 @@ fn test_smart_newline_split_empty_lines() {
 
 #[test]
 fn test_smart_newline_search_l_edge_false_with_crlf() {
-    let searcher = NewLineSearcher;
+    let searcher = NewlineSearcher;
 
     // When edge=false, search_l skips the first byte
     // This test verifies correct offset calculation for both LF and CRLF
@@ -616,9 +616,9 @@ fn test_delimiter_enum_conversions() {
         _ => panic!("Expected Delimiter::Str"),
     }
 
-    // Test conversion from NewLine
-    let delimiter = Delimiter::from(NewLine);
-    assert_eq!(delimiter, Delimiter::NewLine);
+    // Test conversion from Newline
+    let delimiter = Delimiter::from(Newline);
+    assert_eq!(delimiter, Delimiter::Newline);
 }
 
 #[test]
@@ -670,10 +670,10 @@ fn test_auto_delimiter_with_scanner() {
 
 #[test]
 fn test_partial_match_r_position_semantics() {
-    use super::NewLineSearcher;
+    use super::NewlineSearcher;
 
-    // Verify NewLineSearcher correctly returns positions
-    let searcher = NewLineSearcher;
+    // Verify NewlineSearcher correctly returns positions
+    let searcher = NewlineSearcher;
 
     // Buffer ending with CR
     let buf = b"test\r";


### PR DESCRIPTION
Standardize compound word naming convention by renaming:
- `Delimiter::NewLine` to `Delimiter::Newline`
- `NewLine` struct to `Newline`
- `NewLineSearcher` to `NewlineSearcher`
- `Flag::NewLine` to `Flag::Newline`