### PR TITLE
build: improve schema fetch retry behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.0-alpha.4"
+version = "0.36.0-alpha.5"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.0-alpha.4"
+version = "0.36.0-alpha.5"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"


### PR DESCRIPTION
- Cache both successful and failed fetch results to avoid repeated retries for the same failing URL across multiple TOML files
- Use exponential timeout (2s, 4s, 8s) instead of fixed 10s timeout
- Add info-level logging for fetch requests (visible with -vvv)