### PR TITLE
ci(setup): correct shell conditional for cargo-edit detection

### DIFF
--- a/contrib/bin/setup.sh
+++ b/contrib/bin/setup.sh
@@ -95,7 +95,7 @@ setup_cargo_nightly() {
 
 setup_cargo_edit() {
     setup_cargo
-    if [ ! cargo set-version --help >/dev/null 2>&1 ]; then
+    if ! cargo set-version --help >/dev/null 2>&1; then
         cargo install cargo-edit
     fi
 }


### PR DESCRIPTION
The previous form `[ ! cargo set-version --help ]` tested whether the literal string `cargo` was non-empty (always true), so cargo-edit was never installed.

The fix uses `! cargo set-version --help` to correctly negate the command's exit code.