### PR TITLE
fix(pager): remove --mouse from default less arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.1"
+version = "0.36.2-alpha.1"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.1"
+version = "0.36.2-alpha.1"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/etc/defaults/config.toml
+++ b/etc/defaults/config.toml
@@ -254,7 +254,7 @@ name = "less"
 # Base command (executable).
 command = "less"
 # Base arguments for both view and follow modes.
-args = ["-R", "--mouse"]
+args = ["-R"]
 # Environment variables for the pager command.
 env = { LESSCHARSET = "UTF-8" }
 # Additional arguments for follow mode.


### PR DESCRIPTION
The `--mouse` option is not supported in all environments and causes issues when less does not recognize it.