### PR TITLE
build(deps): unpin enumset and upgrade to 1.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ dirs = "6"
 dirs-sys = "0.5"
 encstr = { path = "./crates/encstr" }
 enum-map = "2"
-enumset = "=1.1.10" # see https://github.com/Lymia/enumset/issues/84
+enumset = "1"
 enumset-ext = { path = "./crates/enumset-ext", features = ["clap", "serde"] }
 enumset-serde = { path = "./crates/enumset-serde" }
 env_logger = "0.11"


### PR DESCRIPTION
The issue that required pinning to =1.1.10 has been resolved upstream.
See https://github.com/Lymia/enumset/issues/84