### PR TITLE
fix(fsmon): detect file replacement via atomic rename on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.2"
+version = "0.36.3-alpha.1"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.2"
+version = "0.36.3-alpha.1"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/src/fsmon.rs
+++ b/src/fsmon.rs
@@ -141,6 +141,7 @@ mod imp {
                                 if added.contains(&path) {
                                     watcher.remove_filename(&path, EventFilter::EVFILT_VNODE)?;
                                     added.remove(&path);
+                                    synced = false;
                                 }
                                 Event::new(EventKind::Remove(RemoveKind::Any)).add_path(path)
                             }
@@ -157,6 +158,7 @@ mod imp {
                                 if added.contains(&path) {
                                     watcher.remove_filename(&path, EventFilter::EVFILT_VNODE)?;
                                     added.remove(&path);
+                                    synced = false;
                                 }
                                 Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Any))).add_path(path)
                             }


### PR DESCRIPTION
On macOS, replacing a watched file by renaming another file over it (a common log rotation pattern) was not detected in `--follow` mode, causing output to stop. On Linux this worked correctly.

Closes #1445 