### PR TITLE
fix(changelog): fix padded version strings leaking into release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -2,11 +2,29 @@
 header = ""
 body = """
 {%- macro add_commit(message, author) -%}
-    - {{ message | trim | upper_first | replace(from="{AUTHOR}", to=author | replace(from="[bot]", to="")) }}
+    {%- set clean = self::strip_padding(version=message) -%}
+    - {{ clean | trim | upper_first | replace(from="{AUTHOR}", to=author | replace(from="[bot]", to="")) }}
 {% endmacro -%}
 
 {%- macro strip_padding(version) -%}
-    {{- version | replace(from=".z00000000", to=".0") | replace(from=".z0000000", to=".") | replace(from=".z000000", to=".") | replace(from=".z00000", to=".") | replace(from=".z0000", to=".") | replace(from=".z000", to=".") | replace(from=".z00", to=".") | replace(from=".z0", to=".") | replace(from=".z", to=".") -}}
+    {%- set v = version
+        | replace(from=".z00000000", to=".0")
+        | replace(from=".z0000000", to=".")
+        | replace(from=".z000000", to=".")
+        | replace(from=".z00000", to=".")
+        | replace(from=".z0000", to=".")
+        | replace(from=".z000", to=".")
+        | replace(from=".z00", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z", to=".") -%}
+    {{- v -}}
 {%- endmacro -%}
 
 {%- macro bump_finalize(pkg, first_from, last_to, pr_numbers, author) -%}


### PR DESCRIPTION
Version numbers are temporarily zero-padded for sort ordering (e.g. `1.0.13` → `1.z00000001.z00000013`). The padding was not being stripped before display in some changelog entries, so the raw padded form could appear in the generated output.