### PR TITLE
build: keep version commit hash current for `just install`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.3-alpha.2"
+version = "0.36.3-alpha.3"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.3-alpha.2"
+version = "0.36.3-alpha.3"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,8 @@ fn run() -> Result<()> {
 }
 
 fn set_git_build_info() -> Result<()> {
+    println!("cargo:rerun-if-env-changed=HL_BUILD_SRC_STATE");
+
     let base_version = env!("CARGO_PKG_VERSION");
 
     // Parse the base version

--- a/contrib/bin/setup.sh
+++ b/contrib/bin/setup.sh
@@ -93,17 +93,30 @@ setup_cargo_nightly() {
     fi
 }
 
+setup_cargo_binstall() {
+    if [ -x "$(command -v cargo-binstall)" ]; then
+        true
+    elif [ -x "$(command -v scoop)" ]; then
+        scoop install cargo-binstall
+    elif [ -x "$(command -v cargo)" ]; then
+        cargo install cargo-binstall
+    else
+        echo "Please install cargo-binstall"
+        exit 1
+    fi
+}
+
 setup_cargo_edit() {
-    setup_cargo
     if ! cargo set-version --help >/dev/null 2>&1; then
-        cargo install cargo-edit
+        setup_cargo_binstall
+        cargo binstall cargo-edit
     fi
 }
 
 setup_rustfilt() {
-    setup_cargo
     if [ ! -x "$(command -v rustfilt)" ]; then
-        cargo install rustfilt
+        setup_cargo_binstall
+        cargo binstall rustfilt
     fi
 }
 
@@ -131,17 +144,17 @@ setup_sed() {
 }
 
 setup_llvm_profdata() {
-    setup_rustup
-    setup_rustc
-    setup_sed
     if [ ! -x "$(command -v $(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's|host: ||p')/bin/llvm-profdata)" ]; then
+        setup_rustup
+        setup_rustc
+        setup_sed
         rustup component add llvm-tools-preview
     fi
 }
 
 setup_clippy() {
-    setup_rustup
     if ! (rustup component list | grep -q 'clippy.*(installed)'); then
+        setup_rustup
         rustup component add clippy
     fi
 }
@@ -155,17 +168,19 @@ setup_cargo_audit() {
         elif [ -x "$(command -v pacman)" ]; then
             sudo pacman -S cargo-audit
         elif [ -x "$(command -v cargo)" ]; then
-            cargo install cargo-audit
+            setup_cargo_binstall
+            cargo binstall cargo-audit
         else
             echo "Please install cargo-audit manually"
+            exit 1
         fi
     fi
 }
 
 setup_cargo_outdated() {
-    setup_cargo
     if [ ! -x "$(command -v cargo-outdated)" ]; then
-        cargo install cargo-outdated
+        setup_cargo_binstall
+        cargo binstall cargo-outdated
     fi
 }
 
@@ -180,9 +195,9 @@ setup_screenshot_tools() {
 }
 
 setup_taplo() {
-    setup_cargo
     if [ ! -x "$(command -v taplo)" ]; then
-        cargo install taplo-cli --locked --features lsp
+        setup_cargo_binstall
+        cargo binstall taplo-cli --locked --features lsp
     fi
 }
 
@@ -194,6 +209,7 @@ setup_tombi() {
             uv add --dev tombi
         else
             echo "Please install tombi manually"
+            exit 1
         fi
     fi
 }
@@ -210,6 +226,7 @@ setup_gh() {
             sudo pacman -S gh
         else
             echo "Please install gh manually"
+            exit 1
         fi
     fi
 }
@@ -225,8 +242,8 @@ setup_git_cliff() {
         elif [ -x "$(command -v pacman)" ]; then
             sudo pacman -S git-cliff
         else
-            setup_cargo
-            cargo install git-cliff --locked
+            setup_cargo_binstall
+            cargo binstall git-cliff --locked
         fi
     fi
 }
@@ -242,8 +259,8 @@ setup_bat() {
         elif [ -x "$(command -v pacman)" ]; then
             sudo pacman -S bat
         else
-            setup_cargo
-            cargo install bat --locked
+            setup_cargo_binstall
+            cargo bininstall bat --locked
         fi
     fi
 }
@@ -256,6 +273,7 @@ setup_markdownlint() {
             npm install markdownlint-cli2 --global
         else
             echo "Please install markdownlint-cli2 manually"
+            exit 1
         fi
     fi
 }

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 # Justfile for hl project - convenient command runner
 # Run `just --list` to see all available commands
 
-previous-tag := "git tag -l \"v*.*.*\" --merged HEAD --sort=-version:refname | head -1"
+set lazy
 
 # NixOS helpers
 
@@ -17,6 +17,15 @@ nix-docker-base := """
         """
 nix-docker := nix-docker-base + nix-docker-image + " "
 nix-result := ".build/nix"
+
+# Previous version tag
+previous-tag := shell("git tag -l \"v*.*.*\" --merged HEAD --sort=-version:refname | head -1")
+
+# Repository state, needed for build metadata in the resulting version
+repository-state := shell('git rev-parse HEAD') / if shell('git status --porcelain') == '' { 'clean' } else { 'dirty' }
+
+# Export repository state for the cargo build script
+export HL_BUILD_SRC_STATE := repository-state
 
 # Recipes
 
@@ -135,7 +144,7 @@ check-schema: (setup "schema")
     taplo check
 
 [doc('Install binary and man pages')]
-install: (setup "build") build-release install-man-pages
+install: (setup "build") install-man-pages
     cargo install --path . --locked
 
 [doc('Install binary and man pages and copy with versioned name')]
@@ -143,8 +152,8 @@ install-versioned: install
     @cp ~/.cargo/bin/hl ~/.cargo/bin/$(~/.cargo/bin/hl --version | tr ' ' '-')
 
 [doc('Install man pages')]
+[script]
 install-man-pages:
-    #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p ~/share/man/man1
     cargo run --release --locked -- --config - --man-page >~/share/man/man1/hl.1.tmp
@@ -164,10 +173,10 @@ bump type="alpha": (setup "cargo-edit")
     cargo set-version --package hl --bump {{ type }}
 
 [doc('List changes since the previous release')]
+[script]
 changes since="auto": (setup "git-cliff" "bat" "gh")
-    #!/usr/bin/env bash
     set -euo pipefail
-    since=$(if [ "{{ since }}" = auto ]; then {{ previous-tag }}; else echo "{{ since }}"; fi)
+    since={{ if since == 'auto' { previous-tag } else { since } }}
     version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "hl") | .version')
     GITHUB_REPO=pamburus/hl \
     GITHUB_TOKEN=$(gh auth token) \
@@ -286,3 +295,8 @@ build-nix-docker-image:
 [private]
 setup *tools:
     @contrib/bin/setup.sh {{ tools }}
+
+# Helper to evaluate repository state hash needed for version build metadata
+[private]
+repository-state:
+    @echo {{ repository-state }}


### PR DESCRIPTION
Previously the embedded commit hash could be stale after switching or creating commits without changing any source files. Installing via `just install` now detects git state changes and always rebuilds version metadata.

* Tool setup now uses `cargo binstall` where available for faster installs
* Setup steps that require unavailable tools now fail fast with a clear error instead of silently continuing