### PR TITLE
ci(justfile): fix `just previous-tag` not printing output

### DIFF
--- a/justfile
+++ b/justfile
@@ -185,7 +185,7 @@ changes since="auto": (setup "git-cliff" "bat" "gh")
 
 [doc('Show previous release tag')]
 previous-tag:
-    @{{ previous-tag }}
+    @echo {{ previous-tag }}
 
 [doc('Create screenshots')]
 screenshots: (setup "screenshots") build


### PR DESCRIPTION
The `previous-tag` recipe was invoking the variable directly without `echo`, so it silently evaluated but produced no output.