### PR TITLE
fix(follow): detect in-place file truncation on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hl"
-version = "0.36.3-alpha.3"
+version = "0.36.3-alpha.4"
 dependencies = [
  "anstream",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.36.3-alpha.3"
+version = "0.36.3-alpha.4"
 edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"

--- a/src/fsmon.rs
+++ b/src/fsmon.rs
@@ -109,11 +109,16 @@ mod imp {
         let mut added = HashSet::<&PathBuf>::new();
         let mut synced = true;
 
+        // NOTE_ATTRIB is required to detect in-place truncation (O_TRUNC) on APFS/macOS.
+        // APFS fires NOTE_ATTRIB for file-size metadata changes (truncation) rather than
+        // NOTE_WRITE, so without this flag the follower misses the transient size=0 state
+        // and cannot seek to offset 0 before the subsequent write fills the file again.
         let flags = FilterFlag::NOTE_FFNOP
             | FilterFlag::NOTE_DELETE
             | FilterFlag::NOTE_WRITE
             | FilterFlag::NOTE_RENAME
-            | FilterFlag::NOTE_EXTEND;
+            | FilterFlag::NOTE_EXTEND
+            | FilterFlag::NOTE_ATTRIB;
 
         loop {
             for path in &paths {


### PR DESCRIPTION
New content written after an in-place truncation was silently skipped instead of being re-delivered from the start of the rewritten file in follow mode.