### PR TITLE
 build: avoid deprecated nixfmt directory argument

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,11 +5,11 @@ set lazy
 
 # NixOS helpers
 
-nix-files := "."
+nix-files := "flake.nix nix/*.nix"
 nix-docker-image := "hl-nixos-helper"
 nix-docker-base := """
     docker run --rm \
-        -it \
+        -t \
         --platform=linux/$(uname -m) \
         --security-opt seccomp=unconfined \
         -v "$(pwd)":/etc/nixos \


### PR DESCRIPTION
## Summary

Eliminate the deprecation warning emitted by `just fmt-nix` / `just fmt-check-nix` on every run.

`nixfmt` 2.x deprecated passing a directory (`.`) as an argument:

> Passing directories or non-Nix files (such as ".") is deprecated and will be unsupported soon. Please use the `pkgs.nixfmt-tree` wrapper instead, or https://github.com/numtide/treefmt-nix for more flexibility

## Changes

- Replace the `nix-files := "."` default with an explicit list of the repo's Nix files (`flake.nix nix/*.nix`), so `nixfmt` receives concrete files instead of a directory.
- Drop interactive mode (`-it` → `-t`) from the docker helper so it runs without a TTY.

## Testing

- `just fmt-nix` — runs clean, no deprecation warning.