### PR TITLE
ci: install rustfilt from prebuilt binary in coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
 
+    env:
+      # renovate: datasource=crate depName=rustfilt
+      RUSTFILT_VERSION: "0.2.1"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -123,6 +127,11 @@ jobs:
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install coverage tools
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        with:
+          tool: rustfilt@${{ env.RUSTFILT_VERSION }}
 
       - name: Generate code coverage
         run: |

--- a/contrib/bin/setup.sh
+++ b/contrib/bin/setup.sh
@@ -99,7 +99,7 @@ setup_cargo_binstall() {
     elif [ -x "$(command -v scoop)" ]; then
         scoop install cargo-binstall
     elif [ -x "$(command -v cargo)" ]; then
-        cargo install cargo-binstall
+        cargo install cargo-binstall --locked
     else
         echo "Please install cargo-binstall"
         exit 1


### PR DESCRIPTION
The `coverage` job is broken on master right now. It is not caused by any PR — [#1519](https://github.com/pamburus/hl/pull/1519), an empty commit on an unmodified `master` tree, reproduces it.

## Cause

`make coverage` falls through to `setup_rustfilt` → `setup_cargo_binstall` → `cargo install cargo-binstall`. With no version pin and no `--locked`, cargo resolves cargo-binstall's dependency graph to newest-compatible versions, which routinely exceed the `1.95` toolchain pinned in `rust-toolchain.toml`:

```
error: failed to compile `cargo-binstall v1.22.0`
  rustc 1.95.0 is not supported by the following packages:
    vergen@10.0.3 requires rustc 1.96.0
```

The culprit rotates — it was `kstring@2.0.4` in July, `vergen@10.0.3` today — so this recurs whenever any transitive dependency bumps its MSRV past ours. Runs on `master` only stayed green because `cargo-binstall` was restored from the Rust cache; the failure surfaces on any cache miss.

## Fix

Install `rustfilt` as a pinned prebuilt binary via `taiki-e/install-action`, matching how `taplo`, `tombi` and `markdownlint` are already handled in this workflow. Nothing is compiled against the pinned toolchain, so tool MSRV no longer couples to ours, and `setup_rustfilt`'s `command -v` check short-circuits before binstall is ever needed.

The coverage path needs nothing else from binstall — `jq` is preinstalled on runners and `llvm-profdata` comes from `rustup component add`.

Also passes `--locked` to the binstall bootstrap so local `make coverage` resolves against cargo-binstall's own tested lockfile.

## Follow-ups (not in this PR)

- `cargo install cross` (`build.yml:123`) and `cargo install cargo-quickinstall` (`release.yml:65`) are the same latent trap — they request `toolchain: stable`, but `rust-toolchain.toml` still pins `cargo` to 1.95.
- The `RUSTFILT_VERSION` pin carries a `# renovate:` annotation, inert until a Renovate config lands to keep these tool pins updated. Dependabot cannot reach versions embedded in workflow env vars or shell scripts.
- `contrib/bin/setup.sh:263` reads `cargo bininstall bat --locked` — typo for `binstall`.