### PR TITLE
build(dependabot): group capnp and capnpc updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,14 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    groups:
+      # capnp and capnpc must move together: the runtime and the code generator share a release
+      # cadence, and a version skew between them leaves the committed generated bindings unable to
+      # compile against the runtime.
+      capnp:
+        patterns:
+          - "capnp"
+          - "capnpc"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Bumping the Cap'n Proto runtime crate and its code generator in separate pull requests lets the two drift apart. The checked-in generated bindings are produced by `capnpc`, so a runtime bump that lands without the matching generator bump leaves them unable to compile — which is exactly what happened with #1505.

Grouping them means Dependabot opens a single pull request that moves both at once.

## Verification

- [x] Configuration change only; no code paths affected
- [ ] CI green