### PR TITLE
build(dependabot): remove the duplicate cargo update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,20 +20,6 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: daily
-      time: "18:00"
-      timezone: "Etc/UTC"
-    open-pull-requests-limit: 0
-    labels:
-      - "dependencies"
-      - "rust"
-      - "security"
-    commit-message:
-      prefix: "build"
-      include: "scope"
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
       interval: weekly
       day: friday
       time: "18:00"


### PR DESCRIPTION
## Problem

Two `cargo` entries share `directory: "/"`, so Dependabot rejects the configuration:

```
Update configs must have a unique combination of 'package-ecosystem', 'directory',
and 'target-branch'. Ecosystem 'cargo' has overlapping directories.
```

This dates to #1340 (2026-02-16) and the check has been red on `master` ever since.

## Why the daily entry can go

Dependabot resolved the overlap by ignoring the daily entry. The weekly one has been handling everything, security updates included:

- Security pull requests #1402, #1404 and #1414 carry `dependencies,rust` — the **weekly** entry's labels. The daily entry's set is `dependencies,rust,security`, and no pull request has ever had the `security` label.
- Those same pull requests bumped `openssl` and `rustls-webpki`, both transitive, while the weekly entry's `allow: dependency-type: direct` was in force — so `allow` does not constrain security updates.
- The `ignore` rules are all scoped with the `version-update:` prefix, which applies to version updates only.

The daily schedule was never load-bearing either: `schedule` governs version updates, and security updates are driven by advisories rather than a cron, and are exempt from `open-pull-requests-limit`.

## Effect

No change to which pull requests get opened. The configuration now states what has actually been happening, and the validation check should go green — which also means a genuine future config error becomes visible instead of hiding behind a permanently red check.

The one thing given up is the option of labelling security pull requests differently, which a single entry cannot do — but that was already not happening.

## Verification

- [x] Only two entries remain, `github-actions` and `cargo`, with no overlapping ecosystem/directory pair
- [ ] Dependabot validation green