### PR TITLE
build(dependabot): raise manifest requirements on cargo updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       timezone: "Etc/UTC"
     allow:
       - dependency-type: direct
+    # Cargo's default strategy widens the existing requirement, which cannot express a semver-
+    # incompatible bump such as 0.1 to 0.2. Dependabot then updates only the lock file, producing a
+    # pull request whose lock file contradicts the manifest and fails `cargo check --locked`.
+    versioning-strategy: increase
     labels:
       - "dependencies"
       - "rust"


### PR DESCRIPTION
## Problem

Cargo's default versioning strategy is to *widen* the existing requirement. That cannot express a semver-incompatible bump such as `0.1` to `0.2`, so Dependabot falls back to updating only `Cargo.lock` — leaving a pull request whose lock file contradicts the manifest:

```
error: cannot update the lock file Cargo.lock because --locked was passed to prevent this
```

This has now happened twice: #1477 (`mockall` 0.14 → 0.15) and #1526 (`chrono-english` 0.1.8 → 0.2.0). Both needed the manifest bumped by hand before they could pass.

## Change

Set `versioning-strategy: increase` on the cargo entry, which per the [options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) "always increase[s] the minimum version requirement to match the new version". Cargo is explicitly listed as supporting the option.

## Effect

Semver-incompatible bumps should arrive with `Cargo.toml` and `Cargo.lock` moved together, so they build. It does not remove the need to review breaking changes — it only stops the pull request from being internally inconsistent before anyone can evaluate it.

## Verification

- [ ] CI green
- [ ] Confirmed on the next semver-incompatible bump — #1526 still needs its manifest fixed by hand, since the strategy only affects newly created pull requests