### PR TITLE
Revert "build(dependabot): raise manifest requirements on cargo updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,6 @@ updates:
       timezone: "Etc/UTC"
     allow:
       - dependency-type: direct
-    # Cargo's default strategy widens the existing requirement, which cannot express a semver-
-    # incompatible bump such as 0.1 to 0.2. Dependabot then updates only the lock file, producing a
-    # pull request whose lock file contradicts the manifest and fails `cargo check --locked`.
-    versioning-strategy: increase
     labels:
       - "dependencies"
       - "rust"


### PR DESCRIPTION
Reverts #1528, which made `.github/dependabot.yml` invalid:

```
The property '#/updates/1/versioning-strategy' value "increase"
did not match one of the following values: lockfile-only, auto
```

Cargo accepts the `versioning-strategy` option but only with the values `lockfile-only` and `auto` — not the full set listed in the options reference. With an invalid value the whole configuration fails to parse, which is worse than the problem #1528 set out to fix.

There is therefore no configuration-level fix for the lock-file-only pull requests. Under `auto`, Dependabot classifies this crate as a library and widens requirements, and a widened requirement cannot express a semver-incompatible bump such as `0.1` to `0.2` — so it updates only the lock file. Those pull requests will keep needing the manifest raised by hand, as #1521 did.

## Verification

- [ ] Dependabot config validation green on master after merge