### PR TITLE
build(dependabot): batch patch updates instead of ignoring them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,15 @@ updates:
         patterns:
           - "capnp"
           - "capnpc"
+      # Patch releases are batched into a single pull request rather than suppressed, so the fixes
+      # still land without one pull request per crate.
+      patch-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
       - dependency-name: "anstream"
         update-types: ["version-update:semver-minor"]
       - dependency-name: "anyhow"


### PR DESCRIPTION
Stacked on #1530 — that revert must land first, otherwise the invalid `versioning-strategy` comes along with it.

## Context

In termframe the same bumps that fail here get their manifest requirement raised: `itertools 0.14 → 0.15` (pamburus/termframe#653) and `sha2 0.10.9 → 0.11.0` (pamburus/termframe#561) both arrived with `Cargo.toml` updated, while the identical bumps here (#1465, #1406) came as lock-file-only pull requests that could not build. The manifest layout is not the difference — termframe has no `[workspace.dependencies]` at all.

Two configuration differences remain. This pull request changes **one** of them, so the effect of each can be observed separately:

| | this PR | held back |
|---|---|---|
| patch releases | wildcard ignore rule replaced by a batched `patch-updates` group | |
| `allow` | | `dependency-type: direct` → `all` |

The wildcard `ignore` is the stronger suspect. The `allow` setting filters *which* dependencies get updates rather than how their requirements are written, and `chrono-english` is a direct dependency that did receive a pull request — so `allow: direct` never excluded it.

## Effect

- Patch releases now land, as a single weekly pull request rather than one per crate.
- The `capnp` group is declared ahead of the catch-all so a capnp patch release cannot be split off on its own, preserving what #1523 established.
- The per-dependency `semver-minor` ignore rules are untouched.

## How to tell whether it worked

Commenting `@dependabot recreate` on #1526 rebuilds that pull request against the merged configuration, so the answer arrives in minutes rather than at the next semver-incompatible bump. If `Cargo.toml` is updated this time, this was the cause; if not, the `allow` change is next.

## Verification

- [ ] Dependabot config validation green after merge
- [ ] #1526 recreated with `Cargo.toml` updated