### PR TITLE
build(dependabot): allow updates for indirect dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       time: "18:00"
       timezone: "Etc/UTC"
     allow:
-      - dependency-type: direct
+      - dependency-type: all
     labels:
       - "dependencies"
       - "rust"


### PR DESCRIPTION
First of two configuration differences between this repository and termframe, applied on its own so the effect of each can be observed separately.

## Context

In termframe the same bumps that fail here get their manifest requirement raised: `itertools 0.14 → 0.15` (pamburus/termframe#653) and `sha2 0.10.9 → 0.11.0` (pamburus/termframe#561) both arrived with `Cargo.toml` updated, while the identical bumps here (#1465, #1406) came as lock-file-only pull requests that could not build. The manifest layout is not the difference — termframe has no `[workspace.dependencies]` at all.

Two configuration differences remain:

| | this PR | #1531 |
|---|---|---|
| `allow` | `dependency-type: direct` → `all` | |
| patch releases | | wildcard ignore rule replaced by a batched group |

## Expectations

I rate this the weaker of the two candidates: `allow` filters *which* dependencies get updates rather than how their requirements are written, and `chrono-english` is a direct dependency that did receive a pull request, so `allow: direct` never excluded it. Worth ruling out first regardless, since it is a single line.

Note the diff is small but the behavioural change is not — every transitive dependency becomes eligible for version updates, so expect more pull requests.

## How to tell whether it worked

Commenting `@dependabot recreate` on #1526 rebuilds that pull request against the merged configuration, so the answer arrives in minutes rather than at the next semver-incompatible bump. If `Cargo.toml` is updated this time, this was the cause and #1531 can be dropped; if not, #1531 is next.

## Verification

- [ ] Dependabot config validation green after merge
- [ ] #1526 recreated with `Cargo.toml` updated