### PR TITLE
Revert "build(dependabot): allow updates for indirect dependencies"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       time: "18:00"
       timezone: "Etc/UTC"
     allow:
-      - dependency-type: all
+      - dependency-type: direct
     labels:
       - "dependencies"
       - "rust"


### PR DESCRIPTION
Reverts #1532.

Recreating #1526 against the merged change produced head `a00baf0e` — a single `dependabot[bot]` commit touching `Cargo.lock` only, exactly as before. So `allow: dependency-type: all` has no bearing on whether the manifest requirement gets raised, and it is not worth the increase in pull request volume from indirect dependencies.

That leaves the wildcard `ignore` rule as the last configuration difference from termframe, which #1531 changes.