### PR TITLE
Revert "build(dependabot): batch patch updates instead of ignoring them"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,15 +40,9 @@ updates:
         patterns:
           - "capnp"
           - "capnpc"
-      # Patch releases are batched into a single pull request rather than suppressed, so the fixes
-      # still land without one pull request per crate.
-      patch-updates:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - "patch"
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
       - dependency-name: "anstream"
         update-types: ["version-update:semver-minor"]
       - dependency-name: "anyhow"


### PR DESCRIPTION
Reverts #1531, restoring the wildcard `version-update:semver-patch` ignore.

The `patch-updates` group is redundant: the [Update dependencies](https://github.com/pamburus/hl/actions/workflows/update.yml) workflow already runs a plain `cargo update` every Friday at 17:00 UTC — an hour before the Dependabot cargo schedule — which sweeps up every patch release in one pull request. Grouping them in Dependabot as well only duplicates that work.

The group was added while diagnosing #1526 on the theory that Dependabot's configuration was involved. It was not: the cause was Dependabot skipping the plain dependency tables of a manifest that defines a workspace dependency table, so this change has no diagnostic value to preserve.