### PR TITLE
Revert "build(cargo): declare dependency versions per crate"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,19 @@ edition = "2024"
 repository = "https://github.com/pamburus/hl"
 license = "MIT"
 
+[workspace.dependencies]
+capnp = "0.27"
+capnpc = "0.27"
+clap = { version = "4", features = ["derive", "env", "string", "wrap_help"] }
+clap_complete = { version = "4" }
+clap_mangen = { git = "https://github.com/pamburus/rust-clap.git", rev = "20f0ffd737581a5ebf7479d2174f2c197f25c94d" }
+json = { package = "serde_json", version = "1", features = ["raw_value"] }
+log = "0.4"
+memchr = "2"
+rstest = "0.26"
+shellwords = "1"
+wildcard = { path = "crates/wildcard" }
+
 [[bench]]
 harness = false
 name = "bench"
@@ -37,14 +50,14 @@ name = "bench"
 [dependencies]
 anstream = "1"
 bytefmt = "0.1"
-capnp = "0.27"
+capnp.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 chrono-english = "0.1"
 chrono-tz = { version = "0.10", features = ["serde"] }
 ciborium = "0.2"
-clap = { version = "4", features = ["derive", "env", "string", "wrap_help"] }
-clap_complete = { version = "4" }
-clap_mangen = { git = "https://github.com/pamburus/rust-clap.git", rev = "20f0ffd737581a5ebf7479d2174f2c197f25c94d" }
+clap = { workspace = true }
+clap_complete = { workspace = true }
+clap_mangen = { workspace = true }
 closure = "0.3"
 collection_macros = "0.2"
 color-print = "0.3"
@@ -71,13 +84,13 @@ hex = "0.4"
 humantime = "2"
 itertools = "0.15"
 itoa = { version = "1", default-features = false }
-json = { package = "serde_json", version = "1", features = ["raw_value"] }
+json.workspace = true
 known-folders = "1"
 liblzma = { version = "*", features = ["static"] }
 lifecycle = { path = "./crates/lifecycle" }
-log = "0.4"
+log.workspace = true
 logos = "0.16"
-memchr = "2"
+memchr.workspace = true
 mline = { path = "./crates/mline" }
 nonzero_ext = "0.3"
 notify = { version = "8", features = ["macos_kqueue"] }
@@ -94,7 +107,7 @@ serde-logfmt = { path = "./crates/serde-logfmt" }
 serde_plain = "1"
 serde-value = "0.7"
 sha2 = "0.11"
-shellwords = "1"
+shellwords.workspace = true
 signal-hook = "0.4"
 snap = "1"
 static_assertions = "1"
@@ -110,7 +123,7 @@ unicode-width = "0.2"
 utf8-supported = "1"
 which = "8"
 wild = "2"
-wildcard = { path = "crates/wildcard" }
+wildcard.workspace = true
 winapi-util = { version = "0.1" }
 wyhash = "0.6"
 yaml = { package = "yaml-peg", version = "1" }
@@ -126,16 +139,16 @@ maplit = "1"
 mockall = "0.15"
 rand = "0.10"
 regex = "1"
-rstest = "0.26"
+rstest.workspace = true
 stats_alloc = "0.1"
 wildmatch = "2"
 
 [build-dependencies]
 anyhow = "1"
-capnpc = "0.27"
+capnpc.workspace = true
 const-str = "1"
 hex = "0.4"
-json = { package = "serde_json", version = "1", features = ["raw_value"] }
+json.workspace = true
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"

--- a/crates/enumset-ext/Cargo.toml
+++ b/crates/enumset-ext/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 workspace = "../.."
 
 [dependencies]
-clap = { version = "4", features = ["derive", "env", "string", "wrap_help"], optional = true }
+clap = { workspace = true, optional = true }
 enumset = { version = "1", features = [] }
 enumset-serde = { path = "../enumset-serde", optional = true }
 serde = { version = "1", optional = true }

--- a/crates/pager/Cargo.toml
+++ b/crates/pager/Cargo.toml
@@ -7,5 +7,5 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-log = "0.4"
-shellwords = "1"
+log.workspace = true
+shellwords.workspace = true

--- a/crates/wildcard/Cargo.toml
+++ b/crates/wildcard/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-memchr = "2"
+memchr.workspace = true
 
 [dev-dependencies]
-rstest = "0.26"
+rstest.workspace = true


### PR DESCRIPTION
Reverts #1534, restoring `[workspace.dependencies]` and the `.workspace = true` declarations.

That change worked around the Dependabot defect by removing the trigger, at the cost of duplicating shared versions across manifests. Centralizing every version in the workspace table achieves the same result without the duplication, and is the conventional layout — that follows in a separate pull request so its diff shows only the move.

The manifests are restored byte-identically to their state before #1534, and `Cargo.lock` is untouched.