### PR TITLE
build(dependabot): hold back chrono-english 0.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,11 @@ updates:
         update-types: ["version-update:semver-minor"]
       - dependency-name: "assert_matches"
         update-types: ["version-update:semver-minor"]
+      # 0.2.0 stopped parsing bare month names such as `january`, which `--since` and `--until` accept.
+      # Reported upstream as stevedonovan/chrono-english#38; the release is also absent from the
+      # project repository (stevedonovan/chrono-english#39). Later releases are still offered.
+      - dependency-name: "chrono-english"
+        versions: ["0.2.0"]
       - dependency-name: "clap"
         update-types: ["version-update:semver-minor"]
       - dependency-name: "clap_complete"


### PR DESCRIPTION
Pins Dependabot away from `chrono-english` 0.2.0 only, so later releases still come through and the hold lifts by itself once a fixed version ships.

Recreates the previously closed #1535. The `@dependabot ignore this version` comment on #1526 was tried instead, but it recorded a blanket condition rather than a version-scoped one:

| Dependency | Ignore Condition |
|-|-|
| chrono-english | `[> 0.1.8]` |

That would suppress the fixed release too. The stored condition is cleared separately with `@dependabot unignore chrono-english`; this entry is what keeps 0.2.0 alone held back.

## Why

0.2.0 stopped parsing bare month names, which `--since` and `--until` accept. Verified against both releases with `Dialect::Uk`:

| input | 0.1.8 | 0.2.0 |
| --- | --- | --- |
| `january` | `2026-01-01` | `ERR: unknown token after month End` |
| `jan` | `2026-01-01` | `ERR: unknown token after month End` |
| `last january` | `2026-01-01` | `ERR: unknown token after month End` |
| `friday` | `2026-08-28` | `2026-08-28` |
| `2 january` | `2026-01-02` | `2026-01-02` |

The cause is upstream: the parser was restructured to allow time-first input, and a fall-through for bare month names became an early return. Reported as [stevedonovan/chrono-english#38](https://github.com/stevedonovan/chrono-english/issues/38). The 0.2.0 sources are also absent from the project repository, reported as [stevedonovan/chrono-english#39](https://github.com/stevedonovan/chrono-english/issues/39).