### PR TITLE
build(cargo): centralize dependency versions in the workspace table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,15 +172,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -293,7 +284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -559,15 +550,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -667,16 +649,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "crypto-common"
@@ -810,23 +782,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -835,7 +797,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1121,16 +1083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,8 +1294,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_plain",
- "sha2 0.10.9",
- "sha2 0.11.0",
+ "sha2",
  "shellwords",
  "signal-hook",
  "snap",
@@ -1792,7 +1743,7 @@ name = "mline"
 version = "0.1.0"
 dependencies = [
  "heapopt",
- "itertools 0.13.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
@@ -2405,7 +2356,7 @@ version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2 0.11.0",
+ "sha2",
  "walkdir",
 ]
 
@@ -2666,24 +2617,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,49 +24,34 @@ members = [
   "crates/wildcard",
 ]
 
-[workspace.package]
-version = "0.36.3"
-edition = "2024"
-repository = "https://github.com/pamburus/hl"
-license = "MIT"
-
 [workspace.dependencies]
+anstream = "1"
+anyhow = "1"
+assert_matches = "1"
+base32 = "0.5"
+byte-strings = "0.3"
+bytefmt = "0.1"
 capnp = "0.27"
 capnpc = "0.27"
-clap = { version = "4", features = ["derive", "env", "string", "wrap_help"] }
-clap_complete = { version = "4" }
-clap_mangen = { git = "https://github.com/pamburus/rust-clap.git", rev = "20f0ffd737581a5ebf7479d2174f2c197f25c94d" }
-json = { package = "serde_json", version = "1", features = ["raw_value"] }
-log = "0.4"
-memchr = "2"
-rstest = "0.26"
-shellwords = "1"
-wildcard = { path = "crates/wildcard" }
-
-[[bench]]
-harness = false
-name = "bench"
-
-[dependencies]
-anstream = "1"
-bytefmt = "0.1"
-capnp.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 chrono-english = "0.1"
 chrono-tz = { version = "0.10", features = ["serde"] }
 ciborium = "0.2"
-clap = { workspace = true }
-clap_complete = { workspace = true }
-clap_mangen = { workspace = true }
+clap = { version = "4", features = ["derive", "env", "string", "wrap_help"] }
+clap_complete = { version = "4" }
+clap_mangen = { git = "https://github.com/pamburus/rust-clap.git", rev = "20f0ffd737581a5ebf7479d2174f2c197f25c94d" }
+clean-path = "0.2"
 closure = "0.3"
 collection_macros = "0.2"
 color-print = "0.3"
 config = { version = "0.15", features = ["json", "toml", "yaml"] }
 const-str = "1"
+criterion = "0.8"
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
 crossbeam-utils = "0.8"
 deko = "0.6"
+derive-where = "1"
 derive_more = { version = "2", features = ["deref", "deref_mut", "display", "eq", "from", "into", "into_iterator"] }
 digest-io = "0.1"
 dirs = "6"
@@ -78,20 +63,26 @@ enumset-ext = { path = "./crates/enumset-ext", features = ["clap", "serde"] }
 enumset-serde = { path = "./crates/enumset-serde" }
 env_logger = "0.11"
 flate2 = "1"
+fnv = "1"
 heapless = "0.9"
 heapopt = { path = "./crates/heapopt" }
 hex = "0.4"
 humantime = "2"
 itertools = "0.15"
 itoa = { version = "1", default-features = false }
-json.workspace = true
+json = { package = "serde_json", version = "1", features = ["raw_value"] }
 known-folders = "1"
+kqueue = "1"
+libc = "0.2"
 liblzma = { version = "*", features = ["static"] }
 lifecycle = { path = "./crates/lifecycle" }
-log.workspace = true
+log = "0.4"
 logos = "0.16"
-memchr.workspace = true
+maplit = "1"
+memchr = "2"
 mline = { path = "./crates/mline" }
+mockall = "0.15"
+more-asserts = "0"
 nonzero_ext = "0.3"
 notify = { version = "8", features = ["macos_kqueue"] }
 num_cpus = "1"
@@ -100,20 +91,27 @@ owo-colors = "4"
 pager = { path = "./crates/pager" }
 pest = "2"
 pest_derive = "2"
+proc-macro2 = "1"
+quote = "1"
+rand = "0.10"
 regex = "1"
+rstest = "0.26"
 rust-embed = "8"
-serde = { version = "1", features = ["derive", "rc"] }
+semver = "1"
+serde = { version = "1", features = ["derive"] }
 serde-logfmt = { path = "./crates/serde-logfmt" }
-serde_plain = "1"
 serde-value = "0.7"
+serde_plain = "1"
 sha2 = "0.11"
-shellwords.workspace = true
+shellwords = "1"
 signal-hook = "0.4"
 snap = "1"
 static_assertions = "1"
+stats_alloc = "0.1"
 strsim = "0.11"
 strum = { version = "0.28", features = ["derive"] }
 styled-help = { path = "./crates/styled-help" }
+syn = { version = "3", features = ["extra-traits", "full"] }
 terminal_size = "0.4"
 thiserror = "2"
 titlecase = "3"
@@ -123,36 +121,128 @@ unicode-width = "0.2"
 utf8-supported = "1"
 which = "8"
 wild = "2"
-wildcard.workspace = true
+wildcard = { path = "crates/wildcard" }
+wildmatch = "2"
 winapi-util = { version = "0.1" }
 wyhash = "0.6"
 yaml = { package = "yaml-peg", version = "1" }
 
+[workspace.package]
+version = "0.36.3"
+edition = "2024"
+repository = "https://github.com/pamburus/hl"
+license = "MIT"
+
+[[bench]]
+harness = false
+name = "bench"
+
+[dependencies]
+anstream.workspace = true
+bytefmt.workspace = true
+capnp.workspace = true
+chrono.workspace = true
+chrono-english.workspace = true
+chrono-tz.workspace = true
+ciborium.workspace = true
+clap.workspace = true
+clap_complete.workspace = true
+clap_mangen.workspace = true
+closure.workspace = true
+collection_macros.workspace = true
+color-print.workspace = true
+config.workspace = true
+const-str.workspace = true
+crossbeam-channel.workspace = true
+crossbeam-queue.workspace = true
+crossbeam-utils.workspace = true
+deko.workspace = true
+derive_more.workspace = true
+digest-io.workspace = true
+dirs.workspace = true
+dirs-sys.workspace = true
+encstr.workspace = true
+enum-map.workspace = true
+enumset.workspace = true
+enumset-ext.workspace = true
+enumset-serde.workspace = true
+env_logger.workspace = true
+flate2.workspace = true
+heapless.workspace = true
+heapopt.workspace = true
+hex.workspace = true
+humantime.workspace = true
+itertools.workspace = true
+itoa.workspace = true
+json.workspace = true
+known-folders.workspace = true
+liblzma.workspace = true
+lifecycle.workspace = true
+log.workspace = true
+logos.workspace = true
+memchr.workspace = true
+mline.workspace = true
+nonzero_ext.workspace = true
+notify.workspace = true
+num_cpus.workspace = true
+once_cell.workspace = true
+owo-colors.workspace = true
+pager.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+regex.workspace = true
+rust-embed.workspace = true
+serde = { workspace = true, features = ["rc"] }
+serde-logfmt.workspace = true
+serde_plain.workspace = true
+serde-value.workspace = true
+sha2.workspace = true
+shellwords.workspace = true
+signal-hook.workspace = true
+snap.workspace = true
+static_assertions.workspace = true
+strsim.workspace = true
+strum.workspace = true
+styled-help.workspace = true
+terminal_size.workspace = true
+thiserror.workspace = true
+titlecase.workspace = true
+toml.workspace = true
+unicode-segmentation.workspace = true
+unicode-width.workspace = true
+utf8-supported.workspace = true
+which.workspace = true
+wild.workspace = true
+wildcard.workspace = true
+winapi-util.workspace = true
+wyhash.workspace = true
+yaml.workspace = true
+
 [dev-dependencies]
-assert_matches = "1"
-base32 = "0.5"
-byte-strings = "0.3"
-clean-path = "0.2"
-criterion = "0.8"
-fnv = "1"
-maplit = "1"
-mockall = "0.15"
-rand = "0.10"
-regex = "1"
+assert_matches.workspace = true
+base32.workspace = true
+byte-strings.workspace = true
+clean-path.workspace = true
+criterion.workspace = true
+fnv.workspace = true
+maplit.workspace = true
+mockall.workspace = true
+rand.workspace = true
+regex.workspace = true
 rstest.workspace = true
-stats_alloc = "0.1"
-wildmatch = "2"
+stats_alloc.workspace = true
+wildmatch.workspace = true
 
 [build-dependencies]
-anyhow = "1"
+anyhow.workspace = true
 capnpc.workspace = true
-const-str = "1"
-hex = "0.4"
+const-str.workspace = true
+hex.workspace = true
 json.workspace = true
-semver = "1"
-serde = { version = "1", features = ["derive"] }
-sha2 = "0.10"
-toml = "1"
+semver.workspace = true
+serde.workspace = true
+sha2.workspace = true
+toml.workspace = true
 
 # Use native-tls on Windows ARM64 to avoid ring/clang requirement
 # Use rustls (default) on all other platforms
@@ -163,10 +253,10 @@ ureq = { version = "3", default-features = false, features = ["gzip", "native-tl
 ureq = "3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-kqueue = "1"
+kqueue.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc.workspace = true
 
 [profile.release]
 opt-level = 3

--- a/crates/encstr/Cargo.toml
+++ b/crates/encstr/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 workspace = "../.."
 
 [dependencies]
-memchr = "2"
+memchr.workspace = true

--- a/crates/enumset-ext/Cargo.toml
+++ b/crates/enumset-ext/Cargo.toml
@@ -9,9 +9,9 @@ workspace = "../.."
 
 [dependencies]
 clap = { workspace = true, optional = true }
-enumset = { version = "1", features = [] }
-enumset-serde = { path = "../enumset-serde", optional = true }
-serde = { version = "1", optional = true }
+enumset.workspace = true
+enumset-serde = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 
 [features]
 clap = ["dep:clap"]

--- a/crates/enumset-serde/Cargo.toml
+++ b/crates/enumset-serde/Cargo.toml
@@ -8,5 +8,5 @@ license.workspace = true
 workspace = "../.."
 
 [dependencies]
-enumset = { version = "1", features = [] }
-serde = { version = "1" }
+enumset.workspace = true
+serde.workspace = true

--- a/crates/heapopt/Cargo.toml
+++ b/crates/heapopt/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-derive-where = "1"
-heapless = "0"
+derive-where.workspace = true
+heapless.workspace = true
 
 [dev-dependencies]
-more-asserts = "0"
+more-asserts.workspace = true

--- a/crates/mline/Cargo.toml
+++ b/crates/mline/Cargo.toml
@@ -8,5 +8,5 @@ license.workspace = true
 workspace = "../.."
 
 [dependencies]
-heapopt = { path = "../heapopt" }
-itertools = "0.13"
+heapopt.workspace = true
+itertools.workspace = true

--- a/crates/serde-logfmt/Cargo.toml
+++ b/crates/serde-logfmt/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 workspace = "../.."
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true

--- a/crates/styled-help/Cargo.toml
+++ b/crates/styled-help/Cargo.toml
@@ -8,6 +8,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "3", features = ["extra-traits", "full"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true


### PR DESCRIPTION
Moves every dependency version into `[workspace.dependencies]`, with each crate inheriting via `workspace = true`. A version is now declared once for the whole repository.

Follows #1538, which reverted the earlier attempt at this — that one removed `[workspace.dependencies]` and duplicated shared versions across manifests instead. This diff therefore shows only the move.

## Why

Dependabot skips the plain dependency tables of any manifest that defines `[workspace.dependencies]` ([`file_updater.rb`](https://github.com/dependabot/dependabot-core/blob/main/cargo/lib/dependabot/cargo/file_updater.rb) dispatches the whole file to a workspace-only updater), so update pull requests changed `Cargo.lock` alone and left manifest requirements behind — a state that does not build when the new version falls outside the recorded requirement (#1526). With every declaration a workspace one, they are all updated again.

Reported upstream as [dependabot/dependabot-core#16037](https://github.com/dependabot/dependabot-core/issues/16037).

## Verification

Confirmed with [`dependabot-cli`](https://github.com/dependabot/cli) against the real cargo updater image, using this repository's exact Dependabot configuration: the `chrono-english` update now writes `chrono-english = "0.2"` into the manifest alongside the lockfile change.

Effective requirements were diffed before and after with a TOML parser, resolving inheritance. Ten declarations change; the rest are identical:

| where | before | after |
| --- | --- | --- |
| root `[build-dependencies]` `sha2` | `0.10` | `0.11` |
| `mline` `itertools` | `0.13` | `0.15` |
| `heapopt` `heapless` | `0` | `0.9` |
| `enumset-ext`, `enumset-serde` `serde` | no features | `["derive"]` |
| `enumset-ext` → `enumset-serde` path | `../enumset-serde` | `./crates/enumset-serde` |
| `mline` → `heapopt` path | `../heapopt` | `./crates/heapopt` |
| `enumset` `features = []` → absent | — | no-op |
| `serde-logfmt` `serde` `1.0` → `1` | — | no-op |

The path rewrites are required, since workspace path dependencies resolve from the workspace root. Unifying `sha2` drops the old 0.10 chain — `sha2`, `digest`, `crypto-common`, `block-buffer`, `generic-array`, `cpufeatures` — from the graph, which is the whole `Cargo.lock` diff.

`just ci` passes.