### PR TITLE
fix(capnp): correct the shebang in the regeneration script

### DIFF
--- a/contrib/bin/regenerate-capnp.sh
+++ b/contrib/bin/regenerate-capnp.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Found by exercising the regeneration workflow on a throwaway `update-*` branch. The job failed before reaching the compiler:

```
contrib/bin/regenerate-capnp.sh: 3: set: Illegal option -o pipefail
```

The first line read `#/bin/bash`, missing the `!`, so it was an ordinary comment rather than a shebang and the runner executed the script with `/bin/sh` — `dash` on Ubuntu, which has no `pipefail`.

It passed locally because `/bin/sh` is bash both on macOS and in the helper container, so the fallback happened to be the intended shell.

`contrib/bin/setup.sh` carries the same typo. It has not caused trouble because it is always invoked through `just`, but it is worth a separate look.

## Verification

- [x] `just regenerate-capnp` still succeeds locally and reports the pinned 1.4.0 compiler
- [ ] The regeneration workflow gets past this step on the test branch