### PR TITLE
chore: ignore the local .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.claude
 /.debug
 /.vscode
+/.worktrees
 /.zed
 /*.log
 /*.log.bz2


### PR DESCRIPTION
Adds `/.worktrees` to `.gitignore` so git worktrees created there don't show up as untracked files.

## Verification

- [x] `git status` is clean with a `.worktrees` directory present